### PR TITLE
Add pre-commit config for backend linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+# Pre-commit hooks for Memento backend
+# Install: pip install pre-commit && pre-commit install
+# Run manually: pre-commit run --all-files
+#
+# These hooks match the CI checks in .github/workflows/ci.yaml
+# Config files are in backend/pyproject.toml and backend/.flake8
+
+repos:
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        files: ^backend/
+        args: ["--settings-path", "backend/pyproject.toml"]
+
+  - repo: https://github.com/psf/black
+    rev: 24.1.1
+    hooks:
+      - id: black
+        files: ^backend/
+        args: ["--config", "backend/pyproject.toml"]
+
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.0.0
+    hooks:
+      - id: flake8
+        files: ^backend/
+        args: ["--config", "backend/.flake8"]


### PR DESCRIPTION
  Adds pre-commit hooks to catch formatting issues before push.
  
  After merge, teammates run once:
  pip install pre-commit && pre-commit install