### PR TITLE
fixed ci workflow triggers and added mypy to pre-commit config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,9 +5,8 @@ name: CI
 
 on:
   push:
-    branches:
+    branches-ignore:
       - main
-      - backend-setup
   pull_request:
     branches:
       - main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,3 +26,11 @@ repos:
       - id: flake8
         files: ^backend/
         args: ["--config", "backend/.flake8"]
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+      - id: mypy
+        files: ^backend/app/
+        pass_filenames: false
+        args: ["--ignore-missing-imports", "backend/app/"]


### PR DESCRIPTION
CI workflow was only triggered on push to "main" and "backend-setup" and after PR. pre-commit did not include mypy checks as carried out in CI

CI workflow now runs after every push to a non-main branch and after a PR before a merge to main.
pre-commit-config.yaml includes mypy checks