### PR TITLE
Add RecognitionPublisher service for real-time result delivery

### DIFF
--- a/backend/app/services/__init__.py
+++ b/backend/app/services/__init__.py
@@ -11,6 +11,7 @@ from .profile_summary import (
     ProfileSummaryResult,
     ProfileSummaryService,
 )
+from .recognition_publisher import RecognitionPublisher
 from .rekognition import RekognitionService
 from .resume_parser import ResumeData, ResumeParser
 
@@ -23,6 +24,7 @@ __all__ = [
     "ProfileSummaryError",
     "ProfileSummaryResult",
     "ProfileSummaryService",
+    "RecognitionPublisher",
     "RekognitionService",
     "ResumeData",
     "ResumeParser",

--- a/backend/app/services/recognition_publisher.py
+++ b/backend/app/services/recognition_publisher.py
@@ -1,0 +1,91 @@
+"""Service for publishing recognition results to Supabase Realtime."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DEDUP_WINDOW_SECONDS = 2.0
+
+
+class RecognitionPublisher:
+    """Publishes face recognition matches to recognition_results table.
+
+    Uses the Supabase admin client (service role) to bypass RLS for inserts.
+    The phone app subscribes to this table via Supabase Realtime.
+    """
+
+    def __init__(self, admin_client: Any) -> None:
+        self.client = admin_client
+        self._recent: dict[tuple[str, str], float] = {}
+
+    def publish(
+        self,
+        *,
+        user_id: str,
+        event_id: str,
+        matched_user_id: str | None,
+        confidence: float,
+    ) -> bool:
+        """Publish a recognition result for phone delivery.
+
+        Returns True if the row was inserted, False if deduplicated or failed.
+        """
+        if matched_user_id and self._is_duplicate(user_id, matched_user_id):
+            logger.debug(
+                "Dedup: skipping %s -> %s (within %.0fs window)",
+                user_id,
+                matched_user_id,
+                DEDUP_WINDOW_SECONDS,
+            )
+            return False
+
+        try:
+            row: dict[str, Any] = {
+                "user_id": user_id,
+                "event_id": event_id,
+                "confidence": round(confidence, 4),
+            }
+            if matched_user_id:
+                row["matched_user_id"] = matched_user_id
+
+            self.client.table("recognition_results").insert(row).execute()
+
+            if matched_user_id:
+                self._record_publish(user_id, matched_user_id)
+
+            logger.info(
+                "Published recognition: wearer=%s matched=%s confidence=%.2f",
+                user_id,
+                matched_user_id or "none",
+                confidence,
+            )
+            return True
+
+        except Exception as e:
+            logger.error("Failed to publish recognition result: %s", e)
+            return False
+
+    def _is_duplicate(self, user_id: str, matched_user_id: str) -> bool:
+        """Check if this match was already published within the dedup window."""
+        key = (user_id, matched_user_id)
+        last_publish = self._recent.get(key)
+        if last_publish is None:
+            return False
+        return (time.monotonic() - last_publish) < DEDUP_WINDOW_SECONDS
+
+    def _record_publish(self, user_id: str, matched_user_id: str) -> None:
+        """Record a publish timestamp for deduplication."""
+        now = time.monotonic()
+        key = (user_id, matched_user_id)
+        self._recent[key] = now
+        self._evict_stale_entries(now)
+
+    def _evict_stale_entries(self, now: float) -> None:
+        """Remove dedup entries older than the window to prevent memory growth."""
+        stale_keys = [k for k, t in self._recent.items() if (now - t) >= DEDUP_WINDOW_SECONDS]
+        for k in stale_keys:
+            del self._recent[k]


### PR DESCRIPTION
This PR introduces a RecognitionPublisher service responsible for inserting face recognition matches into the recognition_results table so they can be delivered to the phone in real time through Supabase Realtime. The service uses the Supabase admin (service role) client to bypass Row Level Security for inserts, ensuring secure backend-controlled writes. It includes built-in deduplication logic that suppresses identical matches within a two-second window, preventing the phone from being flooded with repeated notifications when the glasses capture the same person across consecutive frames. Error handling is intentionally non-throwing so that a failure to publish a result never crashes the recognition endpoint. Additionally, stale deduplication entries are automatically cleaned up to prevent memory growth during long-running sessions.

Will can use it like:
{
publisher = RecognitionPublisher(admin_client)
publisher.publish(
    user_id=wearer_id,
    event_id=event_id,
    matched_user_id=matched_id,
    confidence=0.93
}

Closes #129