### PR TITLE
Fix proxy function export name for Next.js 16

### DIFF
--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -1,7 +1,7 @@
 import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   let supabaseResponse = NextResponse.next({ request });
 
   const supabase = createServerClient(


### PR DESCRIPTION
Renames the exported function in `proxy.ts` from `middleware` to `proxy` — required by Next.js 16, fixes `MIDDLEWARE_INVOCATION_FAILED` 500 on Vercel.