### PR TITLE
fix: resize camera frames to prevent 502 on recognition endpoint

### DIFF
--- a/frontend/src/app/(app)/dashboard/page.tsx
+++ b/frontend/src/app/(app)/dashboard/page.tsx
@@ -132,7 +132,10 @@ export default function DashboardPage() {
               const res = await fetch(`${API_URL}/api/v1/recognition/detect`, {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ image_base64: imageBase64 }),
+                body: JSON.stringify({
+                  image_base64: imageBase64,
+                  event_id: process.env.NEXT_PUBLIC_RECOGNITION_EVENT_ID ?? null,
+                }),
               });
               if (res.ok) {
                 const data = (await res.json()) as FrameDetectionResponse;


### PR DESCRIPTION
## Summary
- Camera frames captured in phone mode were being sent at full resolution, exceeding Railway's proxy request body size limit and returning 502
- Frames are now capped at 640px on the longest side with JPEG quality 0.7, keeping payloads well under the limit
- Closes #218