### PR TITLE
updated docs with manual testing reports

### DIFF
--- a/docs/testing/manual-reports/manual-test-report-002.md
+++ b/docs/testing/manual-reports/manual-test-report-002.md
@@ -4,7 +4,7 @@
 |-------|-------|
 | **Report ID** | MT-002 |
 | **Date** | 2026-03-15 |
-| **Tester** | noddiemgbodille |
+| **Tester** | Noddie Mgbodille |
 | **Test Case ID** | MT-02 |
 | **Requirement ID** | FR-Recognition-Storage (S3 image persistence) |
 

--- a/docs/testing/manual-reports/manual-test-report-002.md
+++ b/docs/testing/manual-reports/manual-test-report-002.md
@@ -1,0 +1,69 @@
+# Manual Test Report #002
+
+| Field | Value |
+|-------|-------|
+| **Report ID** | MT-002 |
+| **Date** | 2026-03-15 |
+| **Tester** | noddiemgbodille |
+| **Test Case ID** | MT-02 |
+| **Requirement ID** | FR-Recognition-Storage (S3 image persistence) |
+
+---
+
+## Test Steps
+
+1. Confirm AWS credentials and region used by backend are set (`AWS_REGION`, access key/secret, bucket env var).
+2. Verify target bucket exists and is reachable:
+   - `aws s3api head-bucket --bucket <bucket-name>`
+3. Start backend locally:
+   - `cd backend && uvicorn app.main:app --reload`
+4. Trigger image upload path used by recognition flow (via app UI or API route that writes to S3).
+5. Validate uploaded object appears in expected key prefix:
+   - `aws s3 ls s3://<bucket-name>/<prefix>/ --recursive | tail`
+6. Attempt retrieval using expected access path (presigned URL or backend retrieval endpoint).
+7. Negative test: intentionally use invalid bucket name in env and repeat upload; verify graceful failure and useful error message.
+8. Negative test: use unsupported file type or oversized payload and verify request validation behavior.
+9. Validate logs for request ID, bucket, key, and failure reason if upload fails.
+
+---
+
+## Expected vs Actual Results
+
+| Expected | Actual | Match? |
+|----------|--------|--------|
+| Bucket connectivity check succeeds for configured bucket | _Fill in after run_ | _TBD_ |
+| Upload returns success and stores object in expected key path | _Fill in after run_ | _TBD_ |
+| Retrieval/presigned access works for uploaded object | _Fill in after run_ | _TBD_ |
+| Invalid bucket configuration fails with actionable error | _Fill in after run_ | _TBD_ |
+| Validation errors returned for invalid file payloads | _Fill in after run_ | _TBD_ |
+
+---
+
+## Outcome
+
+- [ ] **Pass**
+- [ ] **Fail**
+
+---
+
+## Logs / Screenshots / Evidence
+
+```bash
+# Bucket health check
+aws s3api head-bucket --bucket <bucket-name>
+
+# Verify recent uploads
+aws s3 ls s3://<bucket-name>/<prefix>/ --recursive | tail -n 20
+```
+
+- Backend logs showing upload success/failure paths.
+- Screenshot or log snippet of object key created.
+- Evidence of negative test response bodies.
+
+---
+
+## Next Steps
+
+1. If failures occur, add integration tests that mock S3 and cover failed upload/retrieval paths.
+2. Add alerting for sustained S3 upload failure rates.
+3. Document bucket policy/KMS requirements near deployment docs.

--- a/docs/testing/manual-reports/manual-test-report-003.md
+++ b/docs/testing/manual-reports/manual-test-report-003.md
@@ -1,0 +1,72 @@
+# Manual Test Report #003
+
+| Field | Value |
+|-------|-------|
+| **Report ID** | MT-003 |
+| **Date** | 2026-03-15 |
+| **Tester** | noddiemgbodille |
+| **Test Case ID** | MT-03 |
+| **Requirement ID** | FR-Event-Indexer-Lambda |
+
+---
+
+## Test Steps
+
+1. Confirm workflow validation is active for Event Indexer:
+   - `.github/workflows/lambda-event-indexer.yaml` has PR `validate` job.
+2. In a test branch, add a new third-party import to `backend/lambdas/event_indexer/handler.py` without updating `requirements.txt`.
+3. Open PR and verify `validate` job fails on import smoke test (`python -c "import handler"` in container).
+4. Update `backend/lambdas/event_indexer/requirements.txt` with the missing dependency.
+5. Re-run PR checks and verify `validate` now passes.
+6. Merge PR into `main` and verify deploy job executes only after `validate` success.
+7. Invoke Lambda (`memento-event-indexer`) with test payload:
+   - `{"window_minutes":20}`
+8. Confirm CloudWatch logs show processing lifecycle:
+   - started
+   - events found
+   - per-event completion or failure handling
+9. Validate returned payload includes `events_scanned`, `events_completed`, `events_failed`.
+
+---
+
+## Expected vs Actual Results
+
+| Expected | Actual | Match? |
+|----------|--------|--------|
+| PR check fails when imports are missing from requirements | _Fill in after run_ | _TBD_ |
+| PR check passes once requirements are corrected | _Fill in after run_ | _TBD_ |
+| Deployment runs only on push to `main` and after validation | _Fill in after run_ | _TBD_ |
+| Lambda invocation succeeds and logs show normal indexing flow | _Fill in after run_ | _TBD_ |
+| Lambda returns expected summary fields | _Fill in after run_ | _TBD_ |
+
+---
+
+## Outcome
+
+- [ ] **Pass**
+- [ ] **Fail**
+
+---
+
+## Logs / Screenshots / Evidence
+
+- Link to failed PR check (missing dependency scenario).
+- Link to passing PR check after requirements fix.
+- Link to successful deploy run on merge.
+- CloudWatch log excerpts for Lambda invocation.
+
+```bash
+aws lambda invoke \
+  --function-name memento-event-indexer \
+  --payload '{"window_minutes":20}' \
+  --cli-binary-format raw-in-base64-out \
+  /tmp/event-indexer-output.json && cat /tmp/event-indexer-output.json
+```
+
+---
+
+## Next Steps
+
+1. Add a scheduled smoke invocation in non-prod to detect runtime regressions early.
+2. Add alert thresholds for repeated indexing failures.
+3. Add regression test case in test inventory for dependency drift.

--- a/docs/testing/manual-reports/manual-test-report-003.md
+++ b/docs/testing/manual-reports/manual-test-report-003.md
@@ -4,7 +4,7 @@
 |-------|-------|
 | **Report ID** | MT-003 |
 | **Date** | 2026-03-15 |
-| **Tester** | noddiemgbodille |
+| **Tester** | Noddie Mgbodille |
 | **Test Case ID** | MT-03 |
 | **Requirement ID** | FR-Event-Indexer-Lambda |
 

--- a/docs/testing/manual-reports/manual-test-report-004.md
+++ b/docs/testing/manual-reports/manual-test-report-004.md
@@ -1,0 +1,71 @@
+# Manual Test Report #004
+
+| Field | Value |
+|-------|-------|
+| **Report ID** | MT-004 |
+| **Date** | 2026-03-15 |
+| **Tester** | noddiemgbodille |
+| **Test Case ID** | MT-04 |
+| **Requirement ID** | FR-Event-Cleanup-Lambda |
+
+---
+
+## Test Steps
+
+1. Confirm workflow validation is active for Event Cleanup:
+   - `.github/workflows/lambda-event-cleanup.yaml` has PR `validate` job.
+2. In a test branch, add a dependency import in cleanup handler without updating requirements.
+3. Open PR and confirm `validate` job fails import check.
+4. Add required package to `backend/lambdas/event_cleanup/requirements.txt`.
+5. Confirm PR validation passes after fix.
+6. Merge to `main` and confirm deploy runs only after `validate`.
+7. Invoke Lambda (`memento-event-cleanup`) with test payload:
+   - `{"window_hours":24}`
+8. Validate CloudWatch logs for cleanup lifecycle:
+   - pending events identified
+   - collection deletion attempted
+   - cleanup status updated (`in_progress`, `completed` or `failed`)
+9. Validate Lambda response fields and counts are consistent with seeded test data.
+
+---
+
+## Expected vs Actual Results
+
+| Expected | Actual | Match? |
+|----------|--------|--------|
+| PR check fails when dependency declaration is missing | _Fill in after run_ | _TBD_ |
+| PR check passes once requirements are updated | _Fill in after run_ | _TBD_ |
+| Deploy triggers only after merge to `main` and successful validate | _Fill in after run_ | _TBD_ |
+| Cleanup Lambda processes eligible events and returns summary | _Fill in after run_ | _TBD_ |
+| Failures are logged and status is set to `failed` for bad events | _Fill in after run_ | _TBD_ |
+
+---
+
+## Outcome
+
+- [ ] **Pass**
+- [ ] **Fail**
+
+---
+
+## Logs / Screenshots / Evidence
+
+- PR check links (fail and pass states).
+- Deploy run link.
+- CloudWatch logs showing collection deletion behavior.
+
+```bash
+aws lambda invoke \
+  --function-name memento-event-cleanup \
+  --payload '{"window_hours":24}' \
+  --cli-binary-format raw-in-base64-out \
+  /tmp/event-cleanup-output.json && cat /tmp/event-cleanup-output.json
+```
+
+---
+
+## Next Steps
+
+1. Add canary events in a staging environment to verify cleanup safely.
+2. Add alerting for repeated cleanup failures.
+3. Add regression checks for event state transitions in manual inventory.

--- a/docs/testing/manual-reports/manual-test-report-004.md
+++ b/docs/testing/manual-reports/manual-test-report-004.md
@@ -4,7 +4,7 @@
 |-------|-------|
 | **Report ID** | MT-004 |
 | **Date** | 2026-03-15 |
-| **Tester** | noddiemgbodille |
+| **Tester** | Noddie Mgbodille |
 | **Test Case ID** | MT-04 |
 | **Requirement ID** | FR-Event-Cleanup-Lambda |
 

--- a/docs/testing/manual-reports/manual-test-report-005.md
+++ b/docs/testing/manual-reports/manual-test-report-005.md
@@ -4,7 +4,7 @@
 |-------|-------|
 | **Report ID** | MT-005 |
 | **Date** | 2026-03-15 |
-| **Tester** | noddiemgbodille |
+| **Tester** | Noddie Mgbodille |
 | **Test Case ID** | MT-05 |
 | **Requirement ID** | FR-WebSocket-Realtime-Recognition |
 

--- a/docs/testing/manual-reports/manual-test-report-005.md
+++ b/docs/testing/manual-reports/manual-test-report-005.md
@@ -1,0 +1,68 @@
+# Manual Test Report #005
+
+| Field | Value |
+|-------|-------|
+| **Report ID** | MT-005 |
+| **Date** | 2026-03-15 |
+| **Tester** | noddiemgbodille |
+| **Test Case ID** | MT-05 |
+| **Requirement ID** | FR-WebSocket-Realtime-Recognition |
+
+---
+
+## Test Steps
+
+1. Start WebSocket server (`glasses-app` backend, expected on `ws://localhost:8080`).
+2. Start frontend app and confirm `NEXT_PUBLIC_WS_URL` is set correctly (or defaults to `ws://localhost:8080`).
+3. Open dashboard/recognition page and verify initial socket connection event.
+4. Send `start_recognition` message from UI action; verify outbound payload and server `ack`.
+5. Validate handling of `recognition_status` and `recognition_result` messages:
+   - card list updates
+   - timestamp ordering
+   - duplicate profile merge behavior
+6. Send `stop_recognition`; verify recognition loop halts and UI state updates.
+7. Network interruption test:
+   - stop WebSocket server while UI is open
+   - verify disconnect warning appears and app does not crash
+8. Invalid payload test:
+   - send malformed JSON / unknown message type from test client
+   - verify parser rejection and error logging without UI crash
+9. Reconnect test:
+   - restart server and reconnect from UI
+   - verify recognition can restart cleanly.
+
+---
+
+## Expected vs Actual Results
+
+| Expected | Actual | Match? |
+|----------|--------|--------|
+| Client connects and receives `connected`/`ack` style handshake messages | _Fill in after run_ | _TBD_ |
+| `start_recognition` and `stop_recognition` correctly control stream state | _Fill in after run_ | _TBD_ |
+| Recognition results render and update consistently in dashboard | _Fill in after run_ | _TBD_ |
+| Disconnects and malformed messages do not crash frontend | _Fill in after run_ | _TBD_ |
+| Reconnection restores functional recognition flow | _Fill in after run_ | _TBD_ |
+
+---
+
+## Outcome
+
+- [ ] **Pass**
+- [ ] **Fail**
+
+---
+
+## Logs / Screenshots / Evidence
+
+- Browser console logs (`Connected`, `Disconnected`, error handling).
+- WebSocket server logs for received message types.
+- Screen capture of recognition feed before/after reconnect.
+- Optional packet capture from browser DevTools Network > WS frames.
+
+---
+
+## Next Steps
+
+1. Add auto-reconnect backoff if current reconnect behavior is manual-only.
+2. Add structured telemetry for socket disconnect reasons.
+3. Add automated contract tests for allowed message types.

--- a/docs/testing/manual-reports/manual-test-report-006.md
+++ b/docs/testing/manual-reports/manual-test-report-006.md
@@ -1,0 +1,72 @@
+# Manual Test Report #006
+
+| Field | Value |
+|-------|-------|
+| **Report ID** | MT-006 |
+| **Date** | 2026-03-15 |
+| **Tester** | noddiemgbodille |
+| **Test Case ID** | MT-06 |
+| **Requirement ID** | FR-MentraOS-End-to-End-Recognition |
+
+---
+
+## Test Steps
+
+1. Start all local services:
+   - Frontend (`localhost:3000`)
+   - Backend API (`localhost:8000`)
+   - Mentra service (`localhost:3001`, if required by app flow)
+   - WebSocket server (`localhost:8080`)
+2. Start proxy gateway:
+   - `cd proxy && npm install && node gateway.js`
+   - confirm gateway on `http://localhost:3002`
+3. Configure MentraOS app/webview to use the proxy base URL (`http://<host>:3002` or tunnel URL mapped to port 3002).
+4. Authenticate user in MentraOS flow and verify API calls route through proxy endpoints:
+   - `/api` -> backend API (`localhost:8000/api`)
+   - `/ws` -> WebSocket (`localhost:8080`)
+   - `/mentra` -> Mentra backend (`localhost:3001`)
+5. Start recognition from MentraOS client and confirm live result cards appear.
+6. Validate profile detail rendering, image loading, and fallback behavior for null fields.
+7. Test negative path by stopping one downstream service (for example WebSocket); verify error messaging and graceful degradation.
+8. Repeat flow on fresh app restart to verify session continuity and endpoint routing stability.
+
+---
+
+## Expected vs Actual Results
+
+| Expected | Actual | Match? |
+|----------|--------|--------|
+| MentraOS client can access app endpoints via proxy URL | _Fill in after run_ | _TBD_ |
+| API, WebSocket, and Mentra routes are correctly forwarded by gateway | _Fill in after run_ | _TBD_ |
+| Recognition workflow functions end-to-end in MentraOS environment | _Fill in after run_ | _TBD_ |
+| Service outage is handled without unrecoverable client failure | _Fill in after run_ | _TBD_ |
+
+---
+
+## Outcome
+
+- [ ] **Pass**
+- [ ] **Fail**
+
+---
+
+## Logs / Screenshots / Evidence
+
+- Proxy startup log: `Gateway running on port 3002`
+- Proxy request logs (if middleware logging enabled)
+- MentraOS/webview screenshots of recognition flow
+- Browser/console logs showing route usage and failures
+
+---
+
+## Next Steps
+
+1. Add a short runbook for local MentraOS testing with required ports/env vars.
+2. Add health checks for each upstream route behind the proxy.
+3. Consider secure tunnel (`https`) and origin restrictions for non-local testing.
+
+### Why the Proxy Was Needed for Localhost Testing
+
+- MentraOS runs outside the local browser context of your dev machine, so direct `localhost` references in app code can resolve to the device itself rather than your host services.
+- The gateway on port `3002` provides one stable origin that multiplexes multiple local services (`/`, `/api`, `/ws`, `/mentra`) and avoids fragmented host/port configuration.
+- Proxying also reduces cross-origin and mixed-route issues by presenting frontend/API/WebSocket traffic behind a single entry point during local integration testing.

--- a/docs/testing/manual-reports/manual-test-report-006.md
+++ b/docs/testing/manual-reports/manual-test-report-006.md
@@ -4,7 +4,7 @@
 |-------|-------|
 | **Report ID** | MT-006 |
 | **Date** | 2026-03-15 |
-| **Tester** | noddiemgbodille |
+| **Tester** | Noddie Mgbodille |
 | **Test Case ID** | MT-06 |
 | **Requirement ID** | FR-MentraOS-End-to-End-Recognition |
 

--- a/docs/testing/verification-test-inventory.md
+++ b/docs/testing/verification-test-inventory.md
@@ -21,8 +21,12 @@ This structure keeps V&V artifacts in `docs/verification/` while aligning with t
 | UT-01 | FR-3.1 | pytest | Yes | Yes | [GitHub Actions log](https://github.com/ailijevs/memento-1/actions) | Once per build |
 | UT-02 | FR-3.1 | pytest | Yes | Yes | [GitHub Actions log](https://github.com/ailijevs/memento-1/actions) | Once per build |
 | IT-01 | FR-1.x | pytest | Yes | Yes | [GitHub Actions log](https://github.com/ailijevs/memento-1/actions) | Once per build |
-| MT-01 | FR-3.1 | Manual | No | N/A | [docs/verification/manual-test-report-001.md](manual-test-report-001.md) | Every two weeks |
-| MT-02 | FR-1.x | Postman/curl | Partial | No | Not completed yet – target: 2026-02-14 | Every two weeks |
+| MT-01 | FR-3.1 | Manual | No | N/A | [manual-test-report-001.md](manual-reports/manual-test-report-001.md) | Every two weeks |
+| MT-02 | FR-Recognition-Storage | AWS CLI + Manual API/UI | Partial | No | [manual-test-report-002.md](manual-reports/manual-test-report-002.md) | Every two weeks |
+| MT-03 | FR-Event-Indexer-Lambda | GitHub Actions + AWS Lambda + CloudWatch | Partial | Partial (validation in CI) | [manual-test-report-003.md](manual-reports/manual-test-report-003.md) | On Lambda workflow change |
+| MT-04 | FR-Event-Cleanup-Lambda | GitHub Actions + AWS Lambda + CloudWatch | Partial | Partial (validation in CI) | [manual-test-report-004.md](manual-reports/manual-test-report-004.md) | On Lambda workflow change |
+| MT-05 | FR-WebSocket-Realtime-Recognition | Browser DevTools + WebSocket server logs | No | No | [manual-test-report-005.md](manual-reports/manual-test-report-005.md) | Every two weeks |
+| MT-06 | FR-MentraOS-End-to-End-Recognition | MentraOS device/webview + proxy logs | No | No | [manual-test-report-006.md](manual-reports/manual-test-report-006.md) | Before release |
 
 ### Legend
 


### PR DESCRIPTION
Added QA documentation updates for manual testing and inventory traceability.  
This PR adds `manual-test-report-002` to `manual-test-report-006` for S3 validation, Event Indexer/Cleanup Lambda verification, WebSocket behavior, and MentraOS end-to-end testing (including proxy rationale).  
It also updates `docs/testing/verification-test-inventory.md` to include these new MT entries with requirement mapping and evidence links.
