### PR TITLE
fix: persist recognition results in sessionStorage

### DIFF
--- a/frontend/src/app/(app)/dashboard/page.tsx
+++ b/frontend/src/app/(app)/dashboard/page.tsx
@@ -9,6 +9,7 @@ import { Camera, LogOut, ScanFace, Square } from "lucide-react";
 import { SocketClient, type SocketMessage, type ProfileCard } from "@/lib/socket";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+const RESULTS_CACHE_KEY = "recognition_results_cache";
 
 type FrameDetectionResponse = {
   matches: ProfileCard[];
@@ -32,10 +33,26 @@ interface RecognitionResult {
   profile?: ProfileResponse;
 }
 
+function loadCachedResults(): RecognitionResult[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = sessionStorage.getItem(RESULTS_CACHE_KEY);
+    if (!raw) return [];
+    return JSON.parse(raw) as RecognitionResult[];
+  } catch {
+    return [];
+  }
+}
+
+function saveCachedResults(results: RecognitionResult[]) {
+  try {
+    sessionStorage.setItem(RESULTS_CACHE_KEY, JSON.stringify(results));
+  } catch { /* storage full — silently ignore */ }
+}
 
 export default function DashboardPage() {
   const router = useRouter();
-  const [results, setResults] = useState<RecognitionResult[]>([]);
+  const [results, setResults] = useState<RecognitionResult[]>(loadCachedResults);
   const [loading, setLoading] = useState(true);
   const [capturing, setCapturing] = useState(false);
   const [captureLoading, setCaptureLoading] = useState(false);
@@ -101,7 +118,10 @@ export default function DashboardPage() {
     };
   }, []);
 
-  // Stop camera stream and capture loop
+  useEffect(() => {
+    saveCachedResults(results);
+  }, [results]);
+
   function stopCameraStream() {
     cameraActiveRef.current = false;
     if (streamRef.current) {

--- a/frontend/src/app/(app)/profile/[userId]/page.tsx
+++ b/frontend/src/app/(app)/profile/[userId]/page.tsx
@@ -41,10 +41,8 @@ export default function UserProfilePage() {
       api.setToken(session.access_token);
       try {
         const p = await api.getProfileById(userId);
-        if (!hadCache) {
-          setProfile(p);
-          sessionStorage.setItem(`profile_cache_${userId}`, JSON.stringify(p));
-        }
+        setProfile(p);
+        sessionStorage.setItem(`profile_cache_${userId}`, JSON.stringify(p));
       } catch {
         // If fetch fails and we already have cached data, keep showing it
       } finally {


### PR DESCRIPTION
## Summary

Recognition cards were lost when navigating from the dashboard to a profile and back because results were only stored in React component state. This fix persists the results array to sessionStorage on every update and restores it on mount, so the recognition feed survives page navigation. Also ensures the profile detail page always refreshes cached data from the API instead of silently keeping stale cache.

## Changes

- `frontend/src/app/(app)/dashboard/page.tsx`: Added sessionStorage persistence for recognition results (save on change, restore on mount).
- `frontend/src/app/(app)/profile/[userId]/page.tsx`: Always update profile state with fresh API data regardless of cache.

## Test plan

- [ ] Start recognition, get some matches on the dashboard
- [ ] Tap a profile card to navigate to the detail page
- [ ] Press back — recognition results should still be visible
- [ ] Refresh the dashboard — cached results should appear instantly

Closes #211