### PR TITLE
MT 009, integration test for recognition api auth

### DIFF
--- a/docs/testing/manual-reports/manual-test-report-007.md
+++ b/docs/testing/manual-reports/manual-test-report-007.md
@@ -36,28 +36,66 @@ NOTE: Because the app was unavailable at the time of performing the test, the UI
 
 | Expected | Actual | Match? |
 |----------|--------|--------|
-|  |  |  |
+| Return information for both Noddie and Sasha from provided picture | Return information for both Noddie and Sasha from provided picture | Yes |
 
 ---
 
 ### Outcome
 
-- [ ] **Pass**
+- [x] **Pass**
 - [ ] **Fail**
 
 ---
 
 ### Logs / Screenshots / Evidence
 
-- 
+- Output:
+{
+  "matches": [
+    {
+      "user_id": "ab87fdd7-6941-48c9-904f-d60fdeaa55f5",
+      "full_name": "Noddie Mgbodille",
+      "headline": "Founder",
+      "company": "Memento",
+      "photo_path": "profiles/ab87fdd7-6941-48c9-904f-d60fdeaa55f5-onboarding.jpg",
+      "profile_one_liner": "Builds backend and infrastructure systems.",
+      "face_similarity": 96.3,
+      "experience_similarity": null,
+      "bio": null,
+      "location": null,
+      "major": "Computer Science",
+      "graduation_year": 2026,
+      "linkedin_url": null,
+      "profile_summary": null,
+      "experiences": [],
+      "education": []
+    },
+    {
+      "user_id": "c96ffe68-01df-4823-83f9-dded98fae363",
+      "full_name": "Aleksandar (Sasha) Ilijevski",
+      "headline": "Computer Engineering Student at Purdue University",
+      "company": "acuvity",
+      "photo_path": "profiles/c96ffe68-01df-4823-83f9-dded98fae363-onboarding.jpg",
+      "profile_one_liner": "Computer Engineering student at Purdue University with expertise in AI security platforms and startup leadership.",
+      "face_similarity": 94.8,
+      "experience_similarity": null,
+      "bio": "Computer engineering student with a passion for software development and AI technologies. Experienced in leading technical projects and building innovative solutions.",
+      "location": null,
+      "major": "Computer Engineering",
+      "graduation_year": 2026,
+      "linkedin_url": "linkedin.com/in/aleksandar-drago-ilijevski",
+      "profile_summary": "Aleksandar Ilijevski is a computer engineering student at Purdue University, graduating in 2026. He has a strong background in software engineering and entrepreneurship, notably building AI security platforms. Aleksandar holds various leadership roles, including Co-Founder of BuildPurdue and Vice President of Public Relations for the Purdue University ECE Student Society. Additionally, he has gained valuable experience as a software engineer intern at Acuvity and a fellow at the iVenture Accelerator.",
+      "experiences": [{"title": "software engineer intern", "company": "acuvity", "end_date": "2025-12", "start_date": "2025-08", "description": null}, {"title": "cohort 11 fellow", "company": "iventure accelerator", "end_date": "2025-09", "start_date": "2025-05", "description": null}, {"title": "vice president of public relations", "company": "purdue university electrical and computer engineering student society", "end_date": "2026", "start_date": "2025-04", "description": null}, {"title": "co-founder", "company": "buildpurdue", "end_date": "2026", "start_date": "2025-03", "description": null}, {"title": "venture scout", "company": "afore capital", "end_date": "2025-01", "start_date": "2024-10", "description": null}, {"title": "summer intern investing series", "company": "dimensional fund advisors", "end_date": "2024-07", "start_date": "2024-06", "description": null}, {"title": "national science foundation innovation corps graduate", "company": "the grainger college of engineering", "end_date": "2024-07", "start_date": "2024-05", "description": null}, {"title": "newsletter chair", "company": "purdue university electrical and computer engineering student society", "end_date": "2025-04", "start_date": "2024-03", "description": null}, {"title": "cozad business venture challenge participant", "company": "the grainger college of engineering", "end_date": "2024-04", "start_date": "2024-01", "description": null}, {"title": "co-founder", "company": "klink! (iv11)", "end_date": "2025-08", "start_date": "2023-12", "description": null}, {"title": "volunteer - volunteer", "company": "humane indiana", "end_date": "2022-06", "start_date": "2021-08", "description": null}, {"title": "volunteer - volunteer", "company": "indiana state school music association inc", "end_date": "2022-08", "start_date": "2017-08", "description": null}],
+      "education": [{"degree": "bachelors", "school": "purdue university college of engineering", "end_date": "2026", "start_date": "2022-08", "field_of_study": "computer engineering"}, {"degree": null, "school": "munster high school", "end_date": "2022-06", "start_date": "2018-08", "field_of_study": null}, {"degree": null, "school": "munster high school", "end_date": null, "start_date": null, "field_of_study": null}]
+    }
+  ],
+  "processing_time_ms": 487.12,
+  "event_id": "2495503e-fe23-49c9-95b2-245b589f5cb7"
+}
 
 ---
 
 ### Next Steps (as required)
 
-- First, a github issue will be
-- If passed: any regression or edge cases to add?
-- Action items:
-
-1. …
-2. …
+1. Depending on how well the recognition performs in real-time, changes may need to be made to increase efficiency and recognition time.
+2. Perform UAT to guage how well recognition is captured for various users using the physical glasses.

--- a/docs/testing/manual-reports/manual-test-report-009.md
+++ b/docs/testing/manual-reports/manual-test-report-009.md
@@ -1,0 +1,80 @@
+# Manual Test Report #009
+
+| Field | Value |
+|-------|-------|
+| **Report ID** | MT-009 |
+| **Date** | 2026-04-03 |
+| **Tester** | Will Ott |
+| **Test Case ID** | MT-09 |
+| **Requirement ID** | FR-1.1, FR-4.1 |
+
+---
+
+### Test Steps
+
+0. Start all services
+    - frontend: npm run dev
+    - glasses-app: npm run dev (or start command your team uses)
+    - backend: uvicorn app.main:app --reload
+
+1. Prepare envs
+    - Frontend has correct NEXT_PUBLIC_WS_URL and API URL.
+    - glasses-app has:
+        BACKEND_URL
+        RECOGNITION_SERVICE_TOKEN (must match backend)
+    - backend has:
+        RECOGNITION_SERVICE_TOKEN (if enforcing service token)
+        Supabase config so JWT verification works
+2) Positive case (happy path)
+    - Sign into frontend.
+    - Open Recognition page and start scanning in glasses mode.
+    - Expected:
+        WS connects (no auth error in console)
+        start_recognition message is sent
+        backend returns 200 for /recognition/detect
+        frontend receives recognition_result via WS
+3) Negative auth cases (core of this test)
+    - Run each as separate test and record observed UI + logs:
+
+    - Invalid WS JWT (frontend session missing/invalid):
+        Expected WS rejection (invalid_auth_token style), no recognition starts.
+
+    - Missing/wrong service token (glasses-app env):
+        WS may still connect, but backend call should fail with 401; frontend should get recognition error/no results.
+
+    - Missing/invalid backend JWT path (if endpoint requires user JWT from caller):
+        backend returns 401, and frontend should show failure behavior.
+
+---
+
+### Expected vs Actual Results
+
+| Expected | Actual | Match? |
+|----------|--------|--------|
+| Describe expected outcome | Describe observed outcome | Yes / No |
+
+---
+
+### Outcome
+
+- [ ] **Pass**
+- [ ] **Fail**
+
+---
+
+### Logs / Screenshots / Evidence
+
+- Attach or link to logs, screenshots, or other evidence
+- Example: `![Screenshot](path/to/screenshot.png)`
+- Example: `[CI Log](https://...)`
+
+---
+
+### Next Steps (as required)
+
+- If failed: what follow-up is needed?
+- If passed: any regression or edge cases to add?
+- Action items:
+
+1. …
+2. …


### PR DESCRIPTION
### Summary
Adds a new manual test report for WebSocket + recognition-auth integration coverage and links that test intent to existing requirement areas.

### What was added
Added/updated docs/testing/manual-reports/manual-test-report-009.md to document a manual integration scenario covering:
frontend ↔ glasses-app WebSocket behavior,
glasses-app ↔ backend /recognition/detect call path,
auth validation outcomes (valid vs invalid credentials),
expected user-visible behavior and evidence capture.

### Why this helps
Expands validation beyond backend-only automated tests by covering the real multi-service runtime path.
Provides traceable evidence for end-to-end behavior where CI does not currently simulate full WebSocket + runtime auth conditions.
Improves release confidence for live recognition flows and error handling.