### PR TITLE
feat: add release workflow and dynamic version for /health endpoint

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,100 @@
+# Release workflow
+# Triggers on semantic version tags (e.g. v0.4.0) pushed to main.
+# Sets APP_VERSION for the backend and creates a GitHub Release.
+
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  validate:
+    name: Validate Tag
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.parse.outputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Parse version from tag
+        id: parse
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          echo "version=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Release version: $TAG"
+
+      - name: Ensure tag is on main
+        run: |
+          git fetch origin main --depth=1
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+            echo "::error::Tag must be created from the main branch."
+            exit 1
+          fi
+
+  test:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    needs: validate
+    defaults:
+      run:
+        working-directory: backend
+    env:
+      SUPABASE_URL: https://test.supabase.co
+      SUPABASE_ANON_KEY: test-anon-key
+      SUPABASE_SERVICE_ROLE_KEY: test-service-role-key
+      SUPABASE_JWT_SECRET: test-jwt-secret-for-ci-testing-only
+      APP_VERSION: ${{ needs.validate.outputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: backend/requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests
+        run: python -m pytest tests/ -v --tb=short
+
+      - name: Verify /health reports correct version
+        run: |
+          VERSION=$(python -c "
+          from app.config import get_settings
+          print(get_settings().app_version)
+          ")
+          EXPECTED="${{ needs.validate.outputs.version }}"
+          echo "Health version: $VERSION"
+          echo "Expected: $EXPECTED"
+          if [ "$VERSION" != "$EXPECTED" ]; then
+            echo "::error::Version mismatch: health=$VERSION expected=$EXPECTED"
+            exit 1
+          fi
+
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: [validate, test]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.validate.outputs.version }}
+          name: ${{ needs.validate.outputs.version }}
+          generate_release_notes: true
+          make_latest: true

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -26,6 +26,7 @@ class Settings(BaseSettings):
 
     # Application Settings
     app_name: str = "Memento API"
+    app_version: str = "0.0.0-dev"
     debug: bool = False
 
     # External APIs (optional)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -57,7 +57,7 @@ def create_app() -> FastAPI:
             "1. Share at least one event membership\n"
             "2. Have consent from the profile owner for that event"
         ),
-        version="1.0.0",
+        version=settings.app_version,
         lifespan=lifespan,
     )
 
@@ -89,7 +89,7 @@ def create_app() -> FastAPI:
         return {
             "status": "healthy",
             "service": settings.app_name,
-            "version": "1.0.0",
+            "version": settings.app_version,
         }
 
     return app


### PR DESCRIPTION
## Summary
- Added a GitHub Actions workflow (`.github/workflows/release.yaml`) that triggers on semantic version tags (e.g. `v0.4.0`) pushed to main.
- The workflow validates the tag is on main, runs tests with `APP_VERSION` set to the tag, verifies `/health` reports the correct version, and creates a GitHub Release linked to the exact tagged commit.
- Updated `config.py` to read `APP_VERSION` from the environment (defaults to `0.0.0-dev` locally).
- Updated `/health` endpoint and FastAPI app version to use the dynamic setting instead of a hardcoded `1.0.0`.

## Test plan
- [ ] Push a tag like `v0.4.0` to main and verify the workflow triggers
- [ ] Verify non-tag pushes do not trigger the release workflow
- [ ] Verify `/health` returns the tag version when `APP_VERSION` is set
- [ ] Verify `/health` returns `0.0.0-dev` when no `APP_VERSION` is set
- [ ] Verify a GitHub Release is created and linked to the tagged commit

Closes #250