### PR TITLE
Feature/consent toggle

### DIFF
--- a/backend/app/api/consents.py
+++ b/backend/app/api/consents.py
@@ -1,22 +1,40 @@
 """API endpoints for event consents."""
 
+import logging
+from datetime import datetime, timezone
 from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from app.auth import CurrentUser, get_current_user
-from app.dals import ConsentDAL
+from app.config import get_settings
+from app.dals import ConsentDAL, EventDAL, ProfileDAL
 from app.db import get_supabase_client
-from app.schemas import ConsentResponse, ConsentUpdate
+from app.schemas import ConsentResponse, ConsentUpdate, EventProcessingStatus
+from app.services.rekognition import RekognitionError, RekognitionService
+from app.utils.rekognition_helpers import build_event_collection_id
 
 router = APIRouter(tags=["events"])
+logger = logging.getLogger(__name__)
 
 
 def get_consent_dal(current_user: Annotated[CurrentUser, Depends(get_current_user)]) -> ConsentDAL:
     """Dependency to get ConsentDAL with authenticated client."""
     client = get_supabase_client(current_user.access_token)
     return ConsentDAL(client)
+
+
+def get_event_dal(current_user: Annotated[CurrentUser, Depends(get_current_user)]) -> EventDAL:
+    """Dependency to get EventDAL with authenticated client."""
+    client = get_supabase_client(current_user.access_token)
+    return EventDAL(client)
+
+
+def get_profile_dal(current_user: Annotated[CurrentUser, Depends(get_current_user)]) -> ProfileDAL:
+    """Dependency to get ProfileDAL with authenticated client."""
+    client = get_supabase_client(current_user.access_token)
+    return ProfileDAL(client)
 
 
 @router.get("/{event_id}/consents/me", response_model=ConsentResponse)
@@ -40,15 +58,109 @@ async def update_my_consent(
     event_id: UUID,
     data: ConsentUpdate,
     current_user: Annotated[CurrentUser, Depends(get_current_user)],
-    dal: Annotated[ConsentDAL, Depends(get_consent_dal)],
+    consent_dal: Annotated[ConsentDAL, Depends(get_consent_dal)],
+    event_dal: Annotated[EventDAL, Depends(get_event_dal)],
+    profile_dal: Annotated[ProfileDAL, Depends(get_profile_dal)],
 ) -> ConsentResponse:
-    """
-    Update consent settings for an event.
-    Timestamps are automatically managed:
-    - consented_at is set when granting consent
-    - revoked_at is set when revoking consent
-    """
-    consent = await dal.update(event_id, current_user.id, data)
+    """Update consent settings for the current user in an event."""
+    event = await event_dal.get_by_id(event_id)
+    if not event:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Event not found.",
+        )
+
+    now = datetime.now(timezone.utc)
+    if event.ends_at and event.ends_at <= now:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Consent can no longer be updated after the event has ended.",
+        )
+
+    current_consent = await consent_dal.get(event_id, current_user.id)
+    if not current_consent:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Consent not found. Are you a member of this event?",
+        )
+
+    recognition_changed = data.allow_recognition is not None and (
+        data.allow_recognition != current_consent.allow_recognition
+    )
+
+    if recognition_changed:
+        if event.indexing_status == EventProcessingStatus.IN_PROGRESS:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    "Event indexing is in progress. "
+                    "Please try updating recognition consent again shortly."
+                ),
+            )
+
+        if event.indexing_status == EventProcessingStatus.COMPLETED:
+            collection_id = build_event_collection_id(event_id)
+            rekognition_service = RekognitionService()
+
+            if data.allow_recognition is True:
+                profile = await profile_dal.get_by_user_id(current_user.id)
+                if not profile or not profile.photo_path:
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="A profile photo is required before enabling recognition.",
+                    )
+
+                settings = get_settings()
+                if not settings.s3_bucket_name:
+                    raise HTTPException(
+                        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                        detail="Recognition storage is not configured.",
+                    )
+
+                try:
+                    rekognition_service.index_face_from_s3(
+                        collection_id=collection_id,
+                        bucket_name=settings.s3_bucket_name,
+                        object_key=profile.photo_path,
+                        image_id=str(current_user.id),
+                    )
+                except (RekognitionError, RuntimeError) as exc:
+                    logger.error(
+                        "Failed to index face for user=%s event=%s while enabling recognition: %s",
+                        current_user.id,
+                        event_id,
+                        exc,
+                    )
+                    raise HTTPException(
+                        status_code=status.HTTP_502_BAD_GATEWAY,
+                        detail="Failed to add your face to event recognition. Please try again.",
+                    ) from exc
+
+            if data.allow_recognition is False:
+                try:
+                    rekognition_service.delete_faces_by_user(
+                        collection_id=collection_id,
+                        user_id=current_user.id,
+                    )
+                except (RekognitionError, RuntimeError) as exc:
+                    logger.error(
+                        (
+                            "Failed to delete face(s) for user=%s "
+                            "event=%s while disabling recognition: %s"
+                        ),
+                        current_user.id,
+                        event_id,
+                        exc,
+                    )
+                    raise HTTPException(
+                        status_code=status.HTTP_502_BAD_GATEWAY,
+                        detail=(
+                            "Failed to remove your face from event recognition. "
+                            "Please try again."
+                        ),
+                    ) from exc
+
+    consent = await consent_dal.update(event_id, current_user.id, data)
     if not consent:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/app/api/events.py
+++ b/backend/app/api/events.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from datetime import datetime, timezone
 from typing import Annotated
 from uuid import UUID
 
@@ -139,6 +140,12 @@ async def delete_event(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Event not found or you don't have permission to delete.",
+        )
+
+    if event.starts_at and datetime.now(timezone.utc) >= event.starts_at:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Events cannot be deleted after they have started.",
         )
 
     indexing_status = event.indexing_status

--- a/backend/app/api/memberships.py
+++ b/backend/app/api/memberships.py
@@ -136,6 +136,12 @@ async def leave_event(
             detail="You are not a member of this event.",
         )
 
+    if event.ends_at and datetime.now(timezone.utc) >= event.ends_at:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You can no longer leave an event after it has ended.",
+        )
+
     indexing_status = event.indexing_status
 
     if indexing_status == EventProcessingStatus.IN_PROGRESS:

--- a/backend/tests/test_consents_update.py
+++ b/backend/tests/test_consents_update.py
@@ -19,6 +19,7 @@ from app.api.consents import (  # noqa: E402
 from app.auth import CurrentUser, get_current_user  # noqa: E402
 from app.main import app  # noqa: E402
 from app.schemas import ConsentResponse, EventProcessingStatus  # noqa: E402
+from app.services.rekognition import RekognitionError  # noqa: E402
 
 
 @pytest.fixture
@@ -289,6 +290,220 @@ def test_update_consent_toggle_recognition_pending_updates_without_rekognition(
 
     assert response.status_code == 200
     assert response.json()["allow_recognition"] is True
+    rekognition_instance.index_face_from_s3.assert_not_called()
+    rekognition_instance.delete_faces_by_user.assert_not_called()
+    consent_dal.update.assert_awaited_once()
+
+
+def test_update_consent_event_not_found_returns_404(client: TestClient):
+    """Return 404 when the event does not exist."""
+    event_id = uuid4()
+    user_id = uuid4()
+    event_dal = SimpleNamespace(get_by_id=AsyncMock(return_value=None))
+    consent_dal = SimpleNamespace(get=AsyncMock(), update=AsyncMock())
+    profile_dal = SimpleNamespace(get_by_user_id=AsyncMock())
+
+    app.dependency_overrides[get_current_user] = lambda: _mock_user(user_id)
+    app.dependency_overrides[get_event_dal] = lambda: event_dal
+    app.dependency_overrides[get_consent_dal] = lambda: consent_dal
+    app.dependency_overrides[get_profile_dal] = lambda: profile_dal
+
+    response = client.patch(
+        f"/api/v1/events/{event_id}/consents/me",
+        json={"allow_profile_display": True},
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Event not found."
+    consent_dal.get.assert_not_awaited()
+    consent_dal.update.assert_not_awaited()
+
+
+def test_update_consent_missing_consent_row_returns_404(client: TestClient):
+    """Return 404 when consent row is missing."""
+    event_id = uuid4()
+    user_id = uuid4()
+    event_dal = SimpleNamespace(
+        get_by_id=AsyncMock(
+            return_value=_event(
+                created_by=uuid4(),
+                ends_at=datetime.now(timezone.utc) + timedelta(hours=1),
+                indexing_status=EventProcessingStatus.PENDING,
+            )
+        )
+    )
+    consent_dal = SimpleNamespace(get=AsyncMock(return_value=None), update=AsyncMock())
+    profile_dal = SimpleNamespace(get_by_user_id=AsyncMock())
+
+    app.dependency_overrides[get_current_user] = lambda: _mock_user(user_id)
+    app.dependency_overrides[get_event_dal] = lambda: event_dal
+    app.dependency_overrides[get_consent_dal] = lambda: consent_dal
+    app.dependency_overrides[get_profile_dal] = lambda: profile_dal
+
+    response = client.patch(
+        f"/api/v1/events/{event_id}/consents/me",
+        json={"allow_profile_display": True},
+    )
+
+    assert response.status_code == 404
+    assert "Consent not found" in response.json()["detail"]
+    consent_dal.update.assert_not_awaited()
+
+
+def test_update_consent_completed_off_rekognition_failure_returns_502(client: TestClient):
+    """Return 502 if deleting faces fails while disabling recognition."""
+    event_id = uuid4()
+    user_id = uuid4()
+    event_dal = SimpleNamespace(
+        get_by_id=AsyncMock(
+            return_value=_event(
+                created_by=uuid4(),
+                ends_at=datetime.now(timezone.utc) + timedelta(hours=1),
+                indexing_status=EventProcessingStatus.COMPLETED,
+            )
+        )
+    )
+    consent_dal = SimpleNamespace(
+        get=AsyncMock(return_value=_consent(event_id, user_id, True, True)),
+        update=AsyncMock(),
+    )
+    profile_dal = SimpleNamespace(get_by_user_id=AsyncMock())
+    rekognition_instance = MagicMock()
+    rekognition_instance.delete_faces_by_user.side_effect = RekognitionError("boom")
+
+    app.dependency_overrides[get_current_user] = lambda: _mock_user(user_id)
+    app.dependency_overrides[get_event_dal] = lambda: event_dal
+    app.dependency_overrides[get_consent_dal] = lambda: consent_dal
+    app.dependency_overrides[get_profile_dal] = lambda: profile_dal
+
+    with patch("app.api.consents.RekognitionService", return_value=rekognition_instance):
+        response = client.patch(
+            f"/api/v1/events/{event_id}/consents/me",
+            json={"allow_recognition": False},
+        )
+
+    assert response.status_code == 502
+    assert "Failed to remove your face" in response.json()["detail"]
+    consent_dal.update.assert_not_awaited()
+
+
+def test_update_consent_completed_on_rekognition_failure_returns_502(client: TestClient):
+    """Return 502 if indexing face fails while enabling recognition."""
+    event_id = uuid4()
+    user_id = uuid4()
+    event_dal = SimpleNamespace(
+        get_by_id=AsyncMock(
+            return_value=_event(
+                created_by=uuid4(),
+                ends_at=datetime.now(timezone.utc) + timedelta(hours=1),
+                indexing_status=EventProcessingStatus.COMPLETED,
+            )
+        )
+    )
+    consent_dal = SimpleNamespace(
+        get=AsyncMock(return_value=_consent(event_id, user_id, True, False)),
+        update=AsyncMock(),
+    )
+    profile_dal = SimpleNamespace(
+        get_by_user_id=AsyncMock(return_value=SimpleNamespace(photo_path="profiles/u1.jpg"))
+    )
+    rekognition_instance = MagicMock()
+    rekognition_instance.index_face_from_s3.side_effect = RekognitionError("boom")
+
+    app.dependency_overrides[get_current_user] = lambda: _mock_user(user_id)
+    app.dependency_overrides[get_event_dal] = lambda: event_dal
+    app.dependency_overrides[get_consent_dal] = lambda: consent_dal
+    app.dependency_overrides[get_profile_dal] = lambda: profile_dal
+
+    with (
+        patch("app.api.consents.RekognitionService", return_value=rekognition_instance),
+        patch(
+            "app.api.consents.get_settings",
+            return_value=SimpleNamespace(s3_bucket_name="test-bucket"),
+        ),
+    ):
+        response = client.patch(
+            f"/api/v1/events/{event_id}/consents/me",
+            json={"allow_recognition": True},
+        )
+
+    assert response.status_code == 502
+    assert "Failed to add your face" in response.json()["detail"]
+    consent_dal.update.assert_not_awaited()
+
+
+def test_update_consent_profile_display_only_update_still_works(client: TestClient):
+    """Non-recognition updates should still be allowed and persisted."""
+    event_id = uuid4()
+    user_id = uuid4()
+    event_dal = SimpleNamespace(
+        get_by_id=AsyncMock(
+            return_value=_event(
+                created_by=uuid4(),
+                ends_at=datetime.now(timezone.utc) + timedelta(hours=1),
+                indexing_status=EventProcessingStatus.IN_PROGRESS,
+            )
+        )
+    )
+    updated = _consent(event_id, user_id, True, False)
+    consent_dal = SimpleNamespace(
+        get=AsyncMock(return_value=_consent(event_id, user_id, False, False)),
+        update=AsyncMock(return_value=updated),
+    )
+    profile_dal = SimpleNamespace(get_by_user_id=AsyncMock())
+    rekognition_instance = MagicMock()
+
+    app.dependency_overrides[get_current_user] = lambda: _mock_user(user_id)
+    app.dependency_overrides[get_event_dal] = lambda: event_dal
+    app.dependency_overrides[get_consent_dal] = lambda: consent_dal
+    app.dependency_overrides[get_profile_dal] = lambda: profile_dal
+
+    with patch("app.api.consents.RekognitionService", return_value=rekognition_instance):
+        response = client.patch(
+            f"/api/v1/events/{event_id}/consents/me",
+            json={"allow_profile_display": True},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["allow_profile_display"] is True
+    rekognition_instance.index_face_from_s3.assert_not_called()
+    rekognition_instance.delete_faces_by_user.assert_not_called()
+    consent_dal.update.assert_awaited_once()
+
+
+def test_update_consent_recognition_noop_does_not_call_rekognition(client: TestClient):
+    """No-op recognition toggle should not call Rekognition and should update normally."""
+    event_id = uuid4()
+    user_id = uuid4()
+    event_dal = SimpleNamespace(
+        get_by_id=AsyncMock(
+            return_value=_event(
+                created_by=uuid4(),
+                ends_at=datetime.now(timezone.utc) + timedelta(hours=1),
+                indexing_status=EventProcessingStatus.COMPLETED,
+            )
+        )
+    )
+    updated = _consent(event_id, user_id, True, True)
+    consent_dal = SimpleNamespace(
+        get=AsyncMock(return_value=_consent(event_id, user_id, True, True)),
+        update=AsyncMock(return_value=updated),
+    )
+    profile_dal = SimpleNamespace(get_by_user_id=AsyncMock())
+    rekognition_instance = MagicMock()
+
+    app.dependency_overrides[get_current_user] = lambda: _mock_user(user_id)
+    app.dependency_overrides[get_event_dal] = lambda: event_dal
+    app.dependency_overrides[get_consent_dal] = lambda: consent_dal
+    app.dependency_overrides[get_profile_dal] = lambda: profile_dal
+
+    with patch("app.api.consents.RekognitionService", return_value=rekognition_instance):
+        response = client.patch(
+            f"/api/v1/events/{event_id}/consents/me",
+            json={"allow_recognition": True},
+        )
+
+    assert response.status_code == 200
     rekognition_instance.index_face_from_s3.assert_not_called()
     rekognition_instance.delete_faces_by_user.assert_not_called()
     consent_dal.update.assert_awaited_once()

--- a/backend/tests/test_consents_update.py
+++ b/backend/tests/test_consents_update.py
@@ -1,0 +1,294 @@
+"""Tests for PATCH /api/v1/events/{event_id}/consents/me behavior."""
+
+import os
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+os.environ["DEBUG"] = "false"
+
+from app.api.consents import (  # noqa: E402
+    get_consent_dal,
+    get_event_dal,
+    get_profile_dal,
+)
+from app.auth import CurrentUser, get_current_user  # noqa: E402
+from app.main import app  # noqa: E402
+from app.schemas import ConsentResponse, EventProcessingStatus  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    """Create a test client with isolated dependency overrides."""
+    app.dependency_overrides.clear()
+    with TestClient(app) as test_client:
+        yield test_client
+    app.dependency_overrides.clear()
+
+
+def _mock_user(user_id: UUID) -> CurrentUser:
+    """Build a mock authenticated user."""
+    return CurrentUser(id=user_id, email="test@example.com", access_token="test-token")
+
+
+def _consent(
+    event_id: UUID,
+    user_id: UUID,
+    allow_profile_display: bool,
+    allow_recognition: bool,
+):
+    """Build a consent response fixture payload."""
+    return ConsentResponse(
+        event_id=event_id,
+        user_id=user_id,
+        allow_profile_display=allow_profile_display,
+        allow_recognition=allow_recognition,
+        consented_at=None,
+        revoked_at=None,
+        updated_at=datetime.now(timezone.utc),
+    )
+
+
+def _event(*, created_by: UUID, ends_at: datetime, indexing_status: EventProcessingStatus):
+    """Build an event-like object used by endpoint logic."""
+    return SimpleNamespace(
+        created_by=created_by,
+        ends_at=ends_at,
+        indexing_status=indexing_status,
+    )
+
+
+def test_update_consent_ended_event_returns_403(client: TestClient):
+    """Reject updates once the event has ended."""
+    event_id = uuid4()
+    user_id = uuid4()
+    event_dal = SimpleNamespace(
+        get_by_id=AsyncMock(
+            return_value=_event(
+                created_by=user_id,
+                ends_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+                indexing_status=EventProcessingStatus.PENDING,
+            )
+        )
+    )
+    consent_dal = SimpleNamespace(get=AsyncMock(), update=AsyncMock())
+    profile_dal = SimpleNamespace(get_by_user_id=AsyncMock())
+
+    app.dependency_overrides[get_current_user] = lambda: _mock_user(user_id)
+    app.dependency_overrides[get_event_dal] = lambda: event_dal
+    app.dependency_overrides[get_consent_dal] = lambda: consent_dal
+    app.dependency_overrides[get_profile_dal] = lambda: profile_dal
+
+    response = client.patch(
+        f"/api/v1/events/{event_id}/consents/me",
+        json={"allow_profile_display": True},
+    )
+
+    assert response.status_code == 403
+    assert "can no longer be updated" in response.json()["detail"]
+    consent_dal.get.assert_not_awaited()
+    consent_dal.update.assert_not_awaited()
+
+
+def test_update_consent_toggle_recognition_in_progress_returns_409(client: TestClient):
+    """Reject recognition toggles while indexing is in progress."""
+    event_id = uuid4()
+    user_id = uuid4()
+    event_dal = SimpleNamespace(
+        get_by_id=AsyncMock(
+            return_value=_event(
+                created_by=uuid4(),
+                ends_at=datetime.now(timezone.utc) + timedelta(hours=1),
+                indexing_status=EventProcessingStatus.IN_PROGRESS,
+            )
+        )
+    )
+    consent_dal = SimpleNamespace(
+        get=AsyncMock(return_value=_consent(event_id, user_id, False, False)),
+        update=AsyncMock(),
+    )
+    profile_dal = SimpleNamespace(get_by_user_id=AsyncMock())
+
+    app.dependency_overrides[get_current_user] = lambda: _mock_user(user_id)
+    app.dependency_overrides[get_event_dal] = lambda: event_dal
+    app.dependency_overrides[get_consent_dal] = lambda: consent_dal
+    app.dependency_overrides[get_profile_dal] = lambda: profile_dal
+
+    response = client.patch(
+        f"/api/v1/events/{event_id}/consents/me",
+        json={"allow_recognition": True},
+    )
+
+    assert response.status_code == 409
+    assert "indexing is in progress" in response.json()["detail"]
+    consent_dal.update.assert_not_awaited()
+
+
+def test_update_consent_toggle_recognition_completed_off_deletes_face_then_updates(
+    client: TestClient,
+):
+    """When disabling recognition post-indexing, remove faces before DB update."""
+    event_id = uuid4()
+    user_id = uuid4()
+    event_dal = SimpleNamespace(
+        get_by_id=AsyncMock(
+            return_value=_event(
+                created_by=uuid4(),
+                ends_at=datetime.now(timezone.utc) + timedelta(hours=1),
+                indexing_status=EventProcessingStatus.COMPLETED,
+            )
+        )
+    )
+    updated = _consent(event_id, user_id, False, False)
+    consent_dal = SimpleNamespace(
+        get=AsyncMock(return_value=_consent(event_id, user_id, False, True)),
+        update=AsyncMock(return_value=updated),
+    )
+    profile_dal = SimpleNamespace(get_by_user_id=AsyncMock())
+    rekognition_instance = MagicMock()
+
+    app.dependency_overrides[get_current_user] = lambda: _mock_user(user_id)
+    app.dependency_overrides[get_event_dal] = lambda: event_dal
+    app.dependency_overrides[get_consent_dal] = lambda: consent_dal
+    app.dependency_overrides[get_profile_dal] = lambda: profile_dal
+
+    with patch("app.api.consents.RekognitionService", return_value=rekognition_instance):
+        response = client.patch(
+            f"/api/v1/events/{event_id}/consents/me",
+            json={"allow_recognition": False},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["allow_recognition"] is False
+    rekognition_instance.delete_faces_by_user.assert_called_once()
+    consent_dal.update.assert_awaited_once()
+
+
+def test_update_consent_toggle_recognition_completed_on_requires_photo(client: TestClient):
+    """Enabling recognition requires an uploaded profile photo."""
+    event_id = uuid4()
+    user_id = uuid4()
+    event_dal = SimpleNamespace(
+        get_by_id=AsyncMock(
+            return_value=_event(
+                created_by=uuid4(),
+                ends_at=datetime.now(timezone.utc) + timedelta(hours=1),
+                indexing_status=EventProcessingStatus.COMPLETED,
+            )
+        )
+    )
+    consent_dal = SimpleNamespace(
+        get=AsyncMock(return_value=_consent(event_id, user_id, False, False)),
+        update=AsyncMock(),
+    )
+    profile_dal = SimpleNamespace(get_by_user_id=AsyncMock(return_value=None))
+    rekognition_instance = MagicMock()
+
+    app.dependency_overrides[get_current_user] = lambda: _mock_user(user_id)
+    app.dependency_overrides[get_event_dal] = lambda: event_dal
+    app.dependency_overrides[get_consent_dal] = lambda: consent_dal
+    app.dependency_overrides[get_profile_dal] = lambda: profile_dal
+
+    with patch("app.api.consents.RekognitionService", return_value=rekognition_instance):
+        response = client.patch(
+            f"/api/v1/events/{event_id}/consents/me",
+            json={"allow_recognition": True},
+        )
+
+    assert response.status_code == 400
+    assert "profile photo is required" in response.json()["detail"]
+    rekognition_instance.index_face_from_s3.assert_not_called()
+    consent_dal.update.assert_not_awaited()
+
+
+def test_update_consent_toggle_recognition_completed_on_indexes_face_then_updates(
+    client: TestClient,
+):
+    """When enabling recognition post-indexing, index face before DB update."""
+    event_id = uuid4()
+    user_id = uuid4()
+    event_dal = SimpleNamespace(
+        get_by_id=AsyncMock(
+            return_value=_event(
+                created_by=uuid4(),
+                ends_at=datetime.now(timezone.utc) + timedelta(hours=1),
+                indexing_status=EventProcessingStatus.COMPLETED,
+            )
+        )
+    )
+    updated = _consent(event_id, user_id, True, True)
+    consent_dal = SimpleNamespace(
+        get=AsyncMock(return_value=_consent(event_id, user_id, False, False)),
+        update=AsyncMock(return_value=updated),
+    )
+    profile_dal = SimpleNamespace(
+        get_by_user_id=AsyncMock(return_value=SimpleNamespace(photo_path="profiles/u1.jpg"))
+    )
+    rekognition_instance = MagicMock()
+
+    app.dependency_overrides[get_current_user] = lambda: _mock_user(user_id)
+    app.dependency_overrides[get_event_dal] = lambda: event_dal
+    app.dependency_overrides[get_consent_dal] = lambda: consent_dal
+    app.dependency_overrides[get_profile_dal] = lambda: profile_dal
+
+    with (
+        patch("app.api.consents.RekognitionService", return_value=rekognition_instance),
+        patch(
+            "app.api.consents.get_settings",
+            return_value=SimpleNamespace(s3_bucket_name="test-bucket"),
+        ),
+    ):
+        response = client.patch(
+            f"/api/v1/events/{event_id}/consents/me",
+            json={"allow_recognition": True},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["allow_recognition"] is True
+    rekognition_instance.index_face_from_s3.assert_called_once()
+    consent_dal.update.assert_awaited_once()
+
+
+def test_update_consent_toggle_recognition_pending_updates_without_rekognition(
+    client: TestClient,
+):
+    """Before indexing completes, recognition toggle should only update consent row."""
+    event_id = uuid4()
+    user_id = uuid4()
+    event_dal = SimpleNamespace(
+        get_by_id=AsyncMock(
+            return_value=_event(
+                created_by=uuid4(),
+                ends_at=datetime.now(timezone.utc) + timedelta(hours=1),
+                indexing_status=EventProcessingStatus.PENDING,
+            )
+        )
+    )
+    updated = _consent(event_id, user_id, False, True)
+    consent_dal = SimpleNamespace(
+        get=AsyncMock(return_value=_consent(event_id, user_id, False, False)),
+        update=AsyncMock(return_value=updated),
+    )
+    profile_dal = SimpleNamespace(get_by_user_id=AsyncMock())
+    rekognition_instance = MagicMock()
+
+    app.dependency_overrides[get_current_user] = lambda: _mock_user(user_id)
+    app.dependency_overrides[get_event_dal] = lambda: event_dal
+    app.dependency_overrides[get_consent_dal] = lambda: consent_dal
+    app.dependency_overrides[get_profile_dal] = lambda: profile_dal
+
+    with patch("app.api.consents.RekognitionService", return_value=rekognition_instance):
+        response = client.patch(
+            f"/api/v1/events/{event_id}/consents/me",
+            json={"allow_recognition": True},
+        )
+
+    assert response.status_code == 200
+    assert response.json()["allow_recognition"] is True
+    rekognition_instance.index_face_from_s3.assert_not_called()
+    rekognition_instance.delete_faces_by_user.assert_not_called()
+    consent_dal.update.assert_awaited_once()

--- a/backend/tests/test_event_time_guards.py
+++ b/backend/tests/test_event_time_guards.py
@@ -1,0 +1,90 @@
+"""Tests for event start/end time guards on delete/leave APIs."""
+
+import os
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+os.environ["DEBUG"] = "false"
+
+from app.api.events import get_event_dal as get_events_event_dal  # noqa: E402
+from app.api.memberships import get_consent_dal as get_memberships_consent_dal  # noqa: E402
+from app.api.memberships import get_event_dal as get_memberships_event_dal  # noqa: E402
+from app.api.memberships import get_membership_dal as get_memberships_membership_dal  # noqa: E402
+from app.auth import CurrentUser, get_current_user  # noqa: E402
+from app.main import app  # noqa: E402
+from app.schemas import EventProcessingStatus  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    """Create a test client with isolated dependency overrides."""
+    app.dependency_overrides.clear()
+    with TestClient(app) as test_client:
+        yield test_client
+    app.dependency_overrides.clear()
+
+
+def _mock_user(user_id: UUID) -> CurrentUser:
+    return CurrentUser(id=user_id, email="test@example.com", access_token="test-token")
+
+
+def test_delete_event_blocked_after_start_time(client: TestClient):
+    """Creators cannot delete events at/after start time."""
+    event_id = uuid4()
+    user_id = uuid4()
+
+    event_dal = SimpleNamespace(
+        get_by_id=AsyncMock(
+            return_value=SimpleNamespace(
+                starts_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+                indexing_status=EventProcessingStatus.PENDING,
+            )
+        ),
+        delete=AsyncMock(),
+    )
+
+    app.dependency_overrides[get_current_user] = lambda: _mock_user(user_id)
+    app.dependency_overrides[get_events_event_dal] = lambda: event_dal
+
+    response = client.delete(f"/api/v1/events/{event_id}")
+
+    assert response.status_code == 403
+    assert "cannot be deleted after they have started" in response.json()["detail"]
+    event_dal.delete.assert_not_awaited()
+
+
+def test_leave_event_blocked_after_end_time(client: TestClient):
+    """Attendees cannot leave events at/after end time."""
+    event_id = uuid4()
+    user_id = uuid4()
+
+    event_dal = SimpleNamespace(
+        get_by_id=AsyncMock(
+            return_value=SimpleNamespace(
+                ends_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+                indexing_status=EventProcessingStatus.PENDING,
+            )
+        )
+    )
+    membership_dal = SimpleNamespace(
+        get=AsyncMock(return_value=SimpleNamespace(event_id=event_id, user_id=user_id)),
+        leave_event=AsyncMock(),
+    )
+    consent_dal = SimpleNamespace(delete=AsyncMock())
+
+    app.dependency_overrides[get_current_user] = lambda: _mock_user(user_id)
+    app.dependency_overrides[get_memberships_event_dal] = lambda: event_dal
+    app.dependency_overrides[get_memberships_membership_dal] = lambda: membership_dal
+    app.dependency_overrides[get_memberships_consent_dal] = lambda: consent_dal
+
+    response = client.delete(f"/api/v1/events/{event_id}/leave")
+
+    assert response.status_code == 403
+    assert "can no longer leave an event after it has ended" in response.json()["detail"]
+    consent_dal.delete.assert_not_awaited()
+    membership_dal.leave_event.assert_not_awaited()

--- a/frontend/src/app/(app)/dashboard/event-consents-sheet-content.tsx
+++ b/frontend/src/app/(app)/dashboard/event-consents-sheet-content.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+import { Ban, Loader2, ShieldCheck } from "lucide-react";
+import type { ConsentResponse } from "@/lib/api";
+
+interface EventConsentsSheetContentProps {
+  loading: boolean;
+  saving: boolean;
+  consent: ConsentResponse | null;
+  onToggleProfileDisplay: (next: boolean) => void;
+  onToggleRecognition: (next: boolean) => void;
+  onGrantAll: () => void;
+  onRevokeAll: () => void;
+}
+
+export function EventConsentsSheetContent({
+  loading,
+  saving,
+  consent,
+  onToggleProfileDisplay,
+  onToggleRecognition,
+  onGrantAll,
+  onRevokeAll,
+}: EventConsentsSheetContentProps) {
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-10">
+        <Loader2 className="h-5 w-5 animate-spin text-white/45" />
+      </div>
+    );
+  }
+
+  if (!consent) {
+    return (
+      <div
+        className="rounded-2xl px-4 py-4 text-[13px] text-white/70"
+        style={{
+          background: "oklch(1 0 0 / 4%)",
+          border: "1px solid oklch(1 0 0 / 10%)",
+        }}
+      >
+        Could not load your event consent settings.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <div
+        className="rounded-2xl p-3 text-[12px] text-white/70"
+        style={{
+          background: "oklch(1 0 0 / 4%)",
+          border: "1px solid oklch(1 0 0 / 10%)",
+        }}
+      >
+        Update how this event can use your profile and face recognition data.
+      </div>
+
+      <ConsentRow
+        title="Profile Display"
+        description="When off, other attendees cannot view your RSVP profile card, your RSVP list visibility is limited, and this also affects post-recognition profile cards for both who you can see and who can see your profile."
+        enabled={consent.allow_profile_display}
+        disabled={saving}
+        onToggle={onToggleProfileDisplay}
+      />
+
+      <ConsentRow
+        title="Face Recognition"
+        description="When on, your profile photo can be added to this event recognition collection. Turning it off removes your face data from this event collection."
+        enabled={consent.allow_recognition}
+        disabled={saving}
+        onToggle={onToggleRecognition}
+      />
+
+      <div className="grid grid-cols-2 gap-2 pt-1">
+        <button
+          onClick={onGrantAll}
+          disabled={saving || (consent.allow_profile_display && consent.allow_recognition)}
+          className="inline-flex items-center justify-center gap-2 rounded-xl px-3 py-2 text-[11px] font-medium uppercase tracking-[0.09em] text-white/85 transition-transform active:scale-95 disabled:opacity-50"
+          style={{
+            background: "oklch(0.23 0.11 145 / 60%)",
+            border: "1px solid oklch(0.58 0.14 145 / 34%)",
+          }}
+        >
+          {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <ShieldCheck className="h-3.5 w-3.5" />}
+          Grant All
+        </button>
+        <button
+          onClick={onRevokeAll}
+          disabled={saving || (!consent.allow_profile_display && !consent.allow_recognition)}
+          className="inline-flex items-center justify-center gap-2 rounded-xl px-3 py-2 text-[11px] font-medium uppercase tracking-[0.09em] text-white/85 transition-transform active:scale-95 disabled:opacity-50"
+          style={{
+            background: "oklch(0.25 0.1 30 / 58%)",
+            border: "1px solid oklch(0.59 0.16 30 / 34%)",
+          }}
+        >
+          {saving ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Ban className="h-3.5 w-3.5" />}
+          Revoke All
+        </button>
+      </div>
+    </div>
+  );
+}
+
+interface ConsentRowProps {
+  title: string;
+  description: string;
+  enabled: boolean;
+  disabled: boolean;
+  onToggle: (next: boolean) => void;
+}
+
+function ConsentRow({ title, description, enabled, disabled, onToggle }: ConsentRowProps) {
+  return (
+    <div
+      className="rounded-2xl p-3"
+      style={{
+        background: "oklch(1 0 0 / 4%)",
+        border: "1px solid oklch(1 0 0 / 10%)",
+      }}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <p className="text-[14px] font-medium text-white/90">{title}</p>
+          <p className="mt-1 text-[12px] text-white/55">{description}</p>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={enabled}
+          aria-label={title}
+          disabled={disabled}
+          onClick={() => onToggle(!enabled)}
+          className="relative inline-flex h-6 w-11 shrink-0 rounded-full transition-colors disabled:opacity-55"
+          style={{
+            background: enabled ? "oklch(0.59 0.18 160 / 90%)" : "oklch(1 0 0 / 18%)",
+            border: enabled
+              ? "1px solid oklch(0.72 0.14 160 / 58%)"
+              : "1px solid oklch(1 0 0 / 20%)",
+          }}
+        >
+          <span
+            className="absolute top-[1px] h-[20px] w-[20px] rounded-full bg-white transition-transform"
+            style={{
+              transform: enabled ? "translateX(21px)" : "translateX(1px)",
+            }}
+          />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(app)/dashboard/page.tsx
+++ b/frontend/src/app/(app)/dashboard/page.tsx
@@ -6,6 +6,7 @@ import { createClient } from "@/lib/supabase/client";
 import {
   api,
   isApiErrorWithStatus,
+  type ConsentResponse,
   type EventResponse,
   type ProfileDirectoryResponse,
 } from "@/lib/api";
@@ -16,6 +17,7 @@ import { AttendeeContent, AttendeeControls, type AttendeeEventItem } from "./att
 import { DiscoverEventsSheetContent, type DiscoverEventItem } from "./discover-events-sheet-content";
 import { OrganizerContent, OrganizerControls } from "./organizer-dashboard";
 import { RsvpListSheetContent } from "./rsvp-list-sheet-content";
+import { EventConsentsSheetContent } from "./event-consents-sheet-content";
 import { getCachedEventConsent, setCachedEventConsent } from "@/lib/consent-cache";
 import {
   CreateEventSheetContent,
@@ -61,6 +63,11 @@ export default function DashboardPage() {
     hidden_count: 0,
   });
   const [showRsvpConsentOffNotice, setShowRsvpConsentOffNotice] = useState(false);
+  const [isEditConsentsOpen, setIsEditConsentsOpen] = useState(false);
+  const [editingConsentsEvent, setEditingConsentsEvent] = useState<EventResponse | null>(null);
+  const [consentsLoading, setConsentsLoading] = useState(false);
+  const [consentsSaving, setConsentsSaving] = useState(false);
+  const [editingConsent, setEditingConsent] = useState<ConsentResponse | null>(null);
   const openMenuContainerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -381,10 +388,49 @@ export default function DashboardPage() {
     }
   }
 
-  function handleEditConsents(event: EventResponse) {
+  async function handleEditConsents(event: EventResponse) {
     setOpenEventMenuId(null);
-    // Intentionally left blank for now.
-    void event;
+    setEditingConsentsEvent(event);
+    setIsEditConsentsOpen(true);
+    setConsentsLoading(true);
+    setActionError(null);
+
+    try {
+      const consent = await api.getMyEventConsent(event.event_id);
+      setEditingConsent(consent);
+      setCachedEventConsent(event.event_id, consent);
+    } catch (error) {
+      console.error("Failed to load event consents:", error);
+      setEditingConsent(null);
+      setActionError("Could not load event consent settings right now. Please try again.");
+    } finally {
+      setConsentsLoading(false);
+    }
+  }
+
+  async function handleConsentUpdate(
+    eventId: string,
+    patch: {
+      allow_profile_display?: boolean;
+      allow_recognition?: boolean;
+    },
+  ) {
+    setConsentsSaving(true);
+    setActionError(null);
+    try {
+      const updated = await api.updateMyEventConsent(eventId, patch);
+      setEditingConsent(updated);
+      setCachedEventConsent(eventId, updated);
+    } catch (error) {
+      console.error("Failed to update event consent:", error);
+      if (error instanceof Error) {
+        setActionError(error.message);
+      } else {
+        setActionError("Could not update event consent right now. Please try again.");
+      }
+    } finally {
+      setConsentsSaving(false);
+    }
   }
 
   return (
@@ -505,7 +551,7 @@ export default function DashboardPage() {
               setOpenEventMenuId((current) => (current === eventId ? null : eventId))
             }
             onViewRsvpList={(event) => void handleViewRsvpList(event)}
-            onEditConsents={handleEditConsents}
+            onEditConsents={(event) => void handleEditConsents(event)}
             onLeaveEvent={(event) => {
               setOpenEventMenuId(null);
               setConfirmLeaveEvent(event);
@@ -604,6 +650,50 @@ export default function DashboardPage() {
           totalCount={rsvpListData.total_count}
           hiddenCount={rsvpListData.hidden_count}
           showConsentOffNotice={showRsvpConsentOffNotice}
+        />
+      </ModalBottomSheet>
+
+      <ModalBottomSheet
+        isOpen={isEditConsentsOpen}
+        onClose={() => {
+          if (!consentsSaving) {
+            setIsEditConsentsOpen(false);
+            setEditingConsentsEvent(null);
+            setEditingConsent(null);
+          }
+        }}
+        title={editingConsentsEvent ? `Edit Consents · ${editingConsentsEvent.name}` : "Edit Consents"}
+      >
+        <EventConsentsSheetContent
+          loading={consentsLoading}
+          saving={consentsSaving}
+          consent={editingConsent}
+          onToggleProfileDisplay={(next) => {
+            if (!editingConsentsEvent) return;
+            void handleConsentUpdate(editingConsentsEvent.event_id, {
+              allow_profile_display: next,
+            });
+          }}
+          onToggleRecognition={(next) => {
+            if (!editingConsentsEvent) return;
+            void handleConsentUpdate(editingConsentsEvent.event_id, {
+              allow_recognition: next,
+            });
+          }}
+          onGrantAll={() => {
+            if (!editingConsentsEvent) return;
+            void handleConsentUpdate(editingConsentsEvent.event_id, {
+              allow_profile_display: true,
+              allow_recognition: true,
+            });
+          }}
+          onRevokeAll={() => {
+            if (!editingConsentsEvent) return;
+            void handleConsentUpdate(editingConsentsEvent.event_id, {
+              allow_profile_display: false,
+              allow_recognition: false,
+            });
+          }}
         />
       </ModalBottomSheet>
 

--- a/frontend/src/app/(app)/recognition/page.tsx
+++ b/frontend/src/app/(app)/recognition/page.tsx
@@ -3,7 +3,13 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
-import { api, type ProfileResponse, type CompatibilityResponse } from "@/lib/api";
+import {
+  api,
+  type ConsentResponse,
+  type ProfileResponse,
+  type CompatibilityResponse,
+} from "@/lib/api";
+import { getCachedEventConsent, setCachedEventConsent } from "@/lib/consent-cache";
 import { Aurora } from "@/components/aurora";
 import { Camera, LogOut, ScanFace, Square } from "lucide-react";
 import { SocketClient, type SocketMessage, type ProfileCard } from "@/lib/socket";
@@ -67,6 +73,7 @@ export default function RecognitionPage() {
   const [capturing, setCapturing] = useState(false);
   const [captureLoading, setCaptureLoading] = useState(false);
   const [cameraMode, setCameraMode] = useState(false);
+  const [consentWarning, setConsentWarning] = useState<string | null>(null);
   const socketRef = useRef<SocketClient | null>(null);
   const mountIdRef = useRef(`dashboard-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
   const videoRef = useRef<HTMLVideoElement | null>(null);
@@ -137,6 +144,45 @@ export default function RecognitionPage() {
   useEffect(() => {
     saveCachedResults(results);
   }, [results]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadConsentWarning() {
+      if (!selectedEventId || !accessTokenRef.current) {
+        setConsentWarning(null);
+        return;
+      }
+
+      let consent: ConsentResponse | null = getCachedEventConsent(selectedEventId);
+      if (!consent) {
+        try {
+          consent = await api.getMyEventConsent(selectedEventId);
+          setCachedEventConsent(selectedEventId, consent);
+        } catch (error) {
+          console.error("[Recognition] Failed to load event consent:", error);
+          return;
+        }
+      }
+
+      if (cancelled) return;
+      if (!consent.allow_profile_display || !consent.allow_recognition) {
+        setConsentWarning(
+          "One or more event consents are off. You will not be able to recognize other attendees.",
+        );
+      } else {
+        setConsentWarning(null);
+      }
+    }
+
+    if (!loading) {
+      void loadConsentWarning();
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [loading, selectedEventId]);
 
   function stopCameraStream() {
     cameraActiveRef.current = false;
@@ -398,6 +444,17 @@ export default function RecognitionPage() {
 
       {/* Content */}
       <div className="relative z-10 flex-1 overflow-y-auto px-6 pb-4">
+        {consentWarning ? (
+          <div
+            className="mb-3 rounded-2xl px-3 py-2 text-[12px] text-amber-200/90"
+            style={{
+              background: "oklch(0.3 0.09 70 / 22%)",
+              border: "1px solid oklch(0.72 0.14 70 / 38%)",
+            }}
+          >
+            {consentWarning}
+          </div>
+        ) : null}
         {loading ? (
           <div className="flex items-center justify-center py-16">
             <div className="h-6 w-6 animate-spin rounded-full border-2 border-white/10 border-t-white/40" />

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -114,6 +114,13 @@ class ApiClient {
     return this.request<ConsentResponse>(`/api/v1/events/${eventId}/consents/me`);
   }
 
+  async updateMyEventConsent(eventId: string, data: ConsentUpdateRequest) {
+    return this.request<ConsentResponse>(`/api/v1/events/${eventId}/consents/me`, {
+      method: "PATCH",
+      body: JSON.stringify(data),
+    });
+  }
+
   async getEventDirectory(eventId: string) {
     return this.request<ProfileDirectoryResponse>(`/api/v1/profiles/directory/${eventId}`);
   }
@@ -218,6 +225,11 @@ export interface EventUpdateRequest {
   ends_at?: string;
   location?: string;
   is_active?: boolean;
+}
+
+export interface ConsentUpdateRequest {
+  allow_profile_display?: boolean;
+  allow_recognition?: boolean;
 }
 
 // ─── Response types ───────────────────────────────────────────────────────────


### PR DESCRIPTION
Consent Update API has been changed to enroll and unenroll faces from event face collection after event indexing has been completed.
Frontend has been updated accordingly to allow users toggle consents and displays descriptions for each consent field
Consent update refreshes local cache to reflect new user consents.
Recognition page displays a disclaimer indicating user recognition disabled due to consents toggled off.
Delete event API only allows creators delete events before event start time.
Leave event API only allows attendees leave events before event end time.

Resolves #202 