### PR TITLE
added api key to frontend from phone camera requests

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -18,10 +18,11 @@ SUPABASE_JWT_SECRET=your-jwt-secret
 APP_NAME=Memento API
 DEBUG=false
 
-# Shared service token sent via the X-Service-Token header to authenticate
-# internal service calls (e.g. glasses app) to the recognition endpoint.
-# When unset, the service-token check is skipped (convenient for local dev).
-RECOGNITION_SERVICE_TOKEN=your-recognition-service-token
+# Recognition API key hash mapping (SHA-256 of raw API keys).
+# Incoming X-Recognition-Api-Key is hashed and matched against these values.
+# If both are unset, recognition API key auth is bypassed (local dev only).
+MENTRA_API_KEY_HASH=sha256-of-mentra-recognition-api-key
+WEB_API_KEY_HASH=sha256-of-web-frontend-recognition-api-key
 
 # Optional AI summary generation
 # Set OPENAI_API_KEY and install `dspy-ai` if you want DSPy-generated summaries.

--- a/backend/app/api/recognition.py
+++ b/backend/app/api/recognition.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from app.auth.dependencies import CurrentUser, get_current_user
-from app.auth.service_auth import verify_service_token
+from app.auth.service_auth import verify_recognition_api_key
 from app.config import get_settings
 from app.dals.event_dal import EventDAL
 from app.db.supabase import get_admin_client
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 @router.post(
     "/detect",
     response_model=FrameDetectionResponse,
-    dependencies=[Depends(verify_service_token)],
+    dependencies=[Depends(verify_recognition_api_key)],
 )
 async def detect_faces_in_frame(
     request: FrameDetectionRequest,

--- a/backend/app/auth/service_auth.py
+++ b/backend/app/auth/service_auth.py
@@ -4,45 +4,62 @@ Service-to-service authentication for internal endpoints.
 Uses two separate credentials:
 - ``Authorization: Bearer <user JWT>`` — authenticates the end user
   (reuses the existing ``get_current_user`` dependency).
-- ``X-Service-Token: <shared secret>`` — authenticates the calling
-  service (e.g. Mentra cloud app).
+- ``X-Recognition-Api-Key: <api key>`` — authenticates the calling
+  client/service (e.g. Mentra app or web frontend).
 
-The service token is compared with ``secrets.compare_digest`` to
-avoid timing-based side-channel leaks.
+The raw API key is hashed with SHA-256 and checked against configured
+hashes in ``settings.hash_to_client``.
 """
 
 from __future__ import annotations
 
-import secrets
+import hashlib
+import logging
 
 from fastapi import Header, HTTPException, status
 
 from app.config import get_settings
 
+logger = logging.getLogger(__name__)
 
-def verify_service_token(
-    x_service_token: str | None = Header(None),
-) -> None:
+
+def _hash_api_key(raw_key: str) -> str:
+    return hashlib.sha256(raw_key.encode("utf-8")).hexdigest()
+
+
+def verify_recognition_api_key(
+    x_recognition_api_key: str | None = Header(None),
+) -> str:
     """
-    Verify the ``X-Service-Token`` header against the configured secret.
+    Verify the ``X-Recognition-Api-Key`` header by hash lookup.
 
-    When ``RECOGNITION_SERVICE_TOKEN`` is **not** configured the check is
+    When no key-hash mappings are configured, the check is
     skipped so local development keeps working without extra setup.
     """
     settings = get_settings()
-    expected = settings.recognition_service_token
+    hash_to_client = settings.hash_to_client
 
-    if not expected:
-        return
+    if not hash_to_client:
+        logger.info("Recognition API key check bypassed: no key hashes configured.")
+        return "unknown"
 
-    if x_service_token is None:
+    if x_recognition_api_key is None:
+        logger.warning("Recognition API key auth failed: missing X-Recognition-Api-Key header.")
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Missing X-Service-Token header",
+            detail="Missing X-Recognition-Api-Key header",
         )
 
-    if not secrets.compare_digest(x_service_token, expected):
+    candidate_hash = _hash_api_key(x_recognition_api_key)
+    client_name = hash_to_client.get(candidate_hash)
+    if not client_name:
+        logger.warning(
+            "Recognition API key auth failed: key hash did not match any configured client."
+        )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid service token",
+            detail="Invalid recognition API key",
         )
+
+    logger.info("Recognition API key auth passed for client=%s", client_name)
+    return client_name

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -31,6 +31,8 @@ class Settings(BaseSettings):
     # External APIs (optional)
     exa_api_key: str | None = None
     mentra_api_key: str | None = None
+    mentra_api_key_hash: str | None = None
+    web_api_key_hash: str | None = None
     pdl_api_key: str | None = None
     openai_api_key: str | None = None
     profile_summary_provider: str = "auto"  # auto | dspy | template
@@ -43,6 +45,16 @@ class Settings(BaseSettings):
     s3_bucket_name: str | None = None
     aws_access_key_id: str | None = None
     aws_secret_access_key: str | None = None
+
+    @property
+    def hash_to_client(self) -> dict[str, str]:
+        """Map known API key hashes to client identifiers."""
+        mapping: dict[str, str] = {}
+        if self.mentra_api_key_hash:
+            mapping[self.mentra_api_key_hash] = "mentra"
+        if self.web_api_key_hash:
+            mapping[self.web_api_key_hash] = "web_frontend"
+        return mapping
 
 
 @lru_cache

--- a/backend/tests/test_recognition.py
+++ b/backend/tests/test_recognition.py
@@ -14,7 +14,7 @@ from app.api.recognition import (
     _resolve_presigned_url_ttl_seconds,
 )
 from app.auth.dependencies import CurrentUser, get_current_user
-from app.auth.service_auth import verify_service_token
+from app.auth.service_auth import verify_recognition_api_key
 from app.main import app
 from app.schemas import (
     EventProcessingStatus,
@@ -338,7 +338,7 @@ class TestFrameDetectionResponseSchema:
         assert response.processing_time_ms == 100.0
 
 
-# --- verify_service_token (unit) ---------------------------------------------
+# --- verify_recognition_api_key (unit) ---------------------------------------
 
 
 FAKE_USER = CurrentUser(
@@ -348,42 +348,49 @@ FAKE_USER = CurrentUser(
 )
 
 
-class TestVerifyServiceToken:
-    """Unit tests for the X-Service-Token dependency."""
+class TestVerifyRecognitionApiKey:
+    """Unit tests for the X-Recognition-Api-Key dependency."""
 
     @patch("app.auth.service_auth.get_settings")
     def test_skips_check_when_not_configured(self, mock_settings):
-        """When no RECOGNITION_SERVICE_TOKEN is set, all requests pass."""
-        mock_settings.return_value = MagicMock(recognition_service_token=None)
-        verify_service_token(x_service_token=None)
+        """When no API key hash mapping is set, all requests pass."""
+        mock_settings.return_value = MagicMock(hash_to_client={})
+        verify_recognition_api_key(x_recognition_api_key=None)
 
     @patch("app.auth.service_auth.get_settings")
-    def test_passes_when_token_matches(self, mock_settings):
-        """Correct X-Service-Token passes validation."""
+    def test_passes_when_api_key_hash_matches(self, mock_settings):
+        """Correct recognition API key passes validation."""
+        import hashlib
+
+        raw_key = "secret-123"
+        key_hash = hashlib.sha256(raw_key.encode("utf-8")).hexdigest()
         mock_settings.return_value = MagicMock(
-            recognition_service_token="secret-123",
+            hash_to_client={key_hash: "mentra"},
         )
-        verify_service_token(x_service_token="secret-123")
+        assert verify_recognition_api_key(x_recognition_api_key=raw_key) == "mentra"
 
     @patch("app.auth.service_auth.get_settings")
     def test_rejects_missing_header(self, mock_settings):
         """Missing header returns 401 when token is configured."""
         mock_settings.return_value = MagicMock(
-            recognition_service_token="secret-123",
+            hash_to_client={"abc": "mentra"},
         )
         with pytest.raises(HTTPException) as exc_info:
-            verify_service_token(x_service_token=None)
+            verify_recognition_api_key(x_recognition_api_key=None)
         assert exc_info.value.status_code == 401
         assert "Missing" in exc_info.value.detail
 
     @patch("app.auth.service_auth.get_settings")
-    def test_rejects_wrong_token(self, mock_settings):
-        """Incorrect X-Service-Token returns 401."""
+    def test_rejects_wrong_api_key(self, mock_settings):
+        """Incorrect X-Recognition-Api-Key returns 401."""
+        import hashlib
+
+        key_hash = hashlib.sha256("secret-123".encode("utf-8")).hexdigest()
         mock_settings.return_value = MagicMock(
-            recognition_service_token="secret-123",
+            hash_to_client={key_hash: "mentra"},
         )
         with pytest.raises(HTTPException) as exc_info:
-            verify_service_token(x_service_token="wrong-token")
+            verify_recognition_api_key(x_recognition_api_key="wrong-token")
         assert exc_info.value.status_code == 401
         assert "Invalid" in exc_info.value.detail
 
@@ -399,16 +406,16 @@ class TestDetectEndpoint:
     ``raw_client`` with targeted patches.
     """
 
-    SERVICE_TOKEN = "test-service-token"
+    RECOGNITION_API_KEY = "test-recognition-api-key"
 
     @pytest.fixture
     def client(self):
         """TestClient with both auth dependencies bypassed."""
         app.dependency_overrides[get_current_user] = lambda: FAKE_USER
-        app.dependency_overrides[verify_service_token] = lambda: None
+        app.dependency_overrides[verify_recognition_api_key] = lambda: "test-client"
         yield TestClient(app)
         app.dependency_overrides.pop(get_current_user, None)
-        app.dependency_overrides.pop(verify_service_token, None)
+        app.dependency_overrides.pop(verify_recognition_api_key, None)
 
     @pytest.fixture
     def raw_client(self):
@@ -592,14 +599,14 @@ class TestDetectEndpoint:
         assert response.status_code == 401
 
     @patch("app.auth.service_auth.get_settings")
-    def test_detect_missing_service_token_returns_401(
+    def test_detect_missing_recognition_api_key_returns_401(
         self,
         mock_settings,
         raw_client,
     ):
-        """Missing X-Service-Token returns 401 when token is configured."""
+        """Missing X-Recognition-Api-Key returns 401 when hash mapping is configured."""
         mock_settings.return_value = MagicMock(
-            recognition_service_token=self.SERVICE_TOKEN,
+            hash_to_client={"abc": "mentra"},
         )
         app.dependency_overrides[get_current_user] = lambda: FAKE_USER
         try:
@@ -615,14 +622,17 @@ class TestDetectEndpoint:
             app.dependency_overrides.pop(get_current_user, None)
 
     @patch("app.auth.service_auth.get_settings")
-    def test_detect_invalid_service_token_returns_401(
+    def test_detect_invalid_recognition_api_key_returns_401(
         self,
         mock_settings,
         raw_client,
     ):
-        """Wrong X-Service-Token returns 401."""
+        """Wrong X-Recognition-Api-Key returns 401."""
+        import hashlib
+
+        key_hash = hashlib.sha256(self.RECOGNITION_API_KEY.encode("utf-8")).hexdigest()
         mock_settings.return_value = MagicMock(
-            recognition_service_token=self.SERVICE_TOKEN,
+            hash_to_client={key_hash: "mentra"},
         )
         app.dependency_overrides[get_current_user] = lambda: FAKE_USER
         try:
@@ -632,7 +642,7 @@ class TestDetectEndpoint:
                     "image_base64": SAMPLE_IMAGE_BASE64,
                     "event_id": None,
                 },
-                headers={"X-Service-Token": "wrong-token"},
+                headers={"X-Recognition-Api-Key": "wrong-token"},
             )
             assert response.status_code == 401
         finally:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,11 @@
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+
+NEXT_PUBLIC_API_URL=http://localhost:8000
+NEXT_PUBLIC_API_DEBUG=true
+NEXT_PUBLIC_WS_URL=ws://localhost:8080
+
+# Recognition API key sent via X-Recognition-Api-Key when calling /recognition/detect.
+# Backend validates hash against WEB_API_KEY_HASH / MENTRA_API_KEY_HASH.
+NEXT_PUBLIC_RECOGNITION_API_KEY=your-web-frontend-recognition-api-key
+

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -31,7 +31,7 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
-.env*
+.env
 
 # vercel
 .vercel

--- a/frontend/src/app/(app)/recognition/page.tsx
+++ b/frontend/src/app/(app)/recognition/page.tsx
@@ -9,6 +9,7 @@ import { Camera, LogOut, ScanFace, Square } from "lucide-react";
 import { SocketClient, type SocketMessage, type ProfileCard } from "@/lib/socket";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+const RECOGNITION_API_KEY = process.env.NEXT_PUBLIC_RECOGNITION_API_KEY?.trim() || null;
 const RESULTS_CACHE_KEY = "recognition_results_cache";
 
 type FrameDetectionResponse = {
@@ -165,9 +166,19 @@ export default function RecognitionPage() {
           const imageBase64 = canvas.toDataURL("image/jpeg", 0.7).split(",")[1];
           if (imageBase64) {
             try {
+              const headers: Record<string, string> = {
+                "Content-Type": "application/json",
+              };
+              if (accessTokenRef.current) {
+                headers["Authorization"] = `Bearer ${accessTokenRef.current}`;
+              }
+              if (RECOGNITION_API_KEY) {
+                headers["X-Recognition-Api-Key"] = RECOGNITION_API_KEY;
+              }
+
               const res = await fetch(`${API_URL}/api/v1/recognition/detect`, {
                 method: "POST",
-                headers: { "Content-Type": "application/json" },
+                headers,
                 body: JSON.stringify({
                   image_base64: imageBase64,
                   event_id: selectedEventId,
@@ -187,6 +198,15 @@ export default function RecognitionPage() {
                   setResults((prev) => upsertRecognitionResult(prev, result));
                   void attachCompatibility(match.user_id);
                 }
+              } else {
+                const errorBody = await res.json().catch(() => null);
+                console.error("[Camera] Recognition HTTP error:", {
+                  status: res.status,
+                  statusText: res.statusText,
+                  detail: errorBody,
+                  hasAuthorization: Boolean(headers.Authorization),
+                  hasRecognitionApiKey: Boolean(headers["X-Recognition-Api-Key"]),
+                });
               }
             } catch (err) {
               console.error("[Camera] Recognition error:", err);

--- a/glasses-app/.env.example
+++ b/glasses-app/.env.example
@@ -8,9 +8,9 @@ BACKEND_URL=http://localhost:8000
 SUPABASE_URL=https://vvodafvmwkvbuurdpcyj.supabase.co
 SUPABASE_JWT_SECRET=AoNLfQKW14HRQY1iLKkZkvHIyQQ2G8BtHQ/WJ2jKs3jbMGnSi2hNYdAi0tuDerCm5Ni0Vc16qFhw1MI2ejPf4A==
 
-# Shared service token (must match RECOGNITION_SERVICE_TOKEN on the backend).
-# Sent via the X-Service-Token header when calling /recognition/detect.
-RECOGNITION_SERVICE_TOKEN=your-recognition-service-token
+# Recognition API key sent via X-Recognition-Api-Key when calling /recognition/detect.
+# Backend validates by hashing this key and matching MENTRA_API_KEY_HASH / WEB_API_KEY_HASH.
+RECOGNITION_API_KEY=your-recognition-api-key
 
 # App Configuration
 PORT=3000

--- a/glasses-app/src/backendClient.ts
+++ b/glasses-app/src/backendClient.ts
@@ -45,9 +45,9 @@ export class BackendClient {
     payload: FrameDetectionRequest,
     userAccessToken?: string,
   ): Promise<FrameDetectionResponse> {
-    const serviceToken = process.env.RECOGNITION_SERVICE_TOKEN;
+    const recognitionApiKey = process.env.RECOGNITION_API_KEY;
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-    if (serviceToken) headers['X-Service-Token'] = serviceToken;
+    if (recognitionApiKey) headers['X-Recognition-Api-Key'] = recognitionApiKey;
     if (userAccessToken) headers['Authorization'] = `Bearer ${userAccessToken}`;
 
     const response = await fetch(this.recognitionUrl, {


### PR DESCRIPTION
Recognition bug fixed and frontend now sends recognition api key along with user jwt to `/recognition/detect` for authentication.
`/recognition/detect` endpoint hashes recognition api key and compares with key hash configured in settings.

Fixes #261 