### PR TITLE
Add clickable event cards with event detail sheet

### DIFF
--- a/backend/app/schemas/event.py
+++ b/backend/app/schemas/event.py
@@ -23,6 +23,8 @@ class EventBase(BaseModel):
     starts_at: datetime | None = None
     ends_at: datetime | None = None
     location: str | None = Field(None, max_length=500)
+    description: str | None = Field(None, max_length=2000)
+    max_participants: int | None = Field(None, gt=0)
     is_active: bool = True
 
     @field_validator("ends_at")
@@ -49,6 +51,8 @@ class EventUpdate(BaseModel):
     starts_at: datetime | None = None
     ends_at: datetime | None = None
     location: str | None = Field(default=None, max_length=500)
+    description: str | None = Field(default=None, max_length=2000)
+    max_participants: int | None = Field(default=None, gt=0)
     is_active: bool | None = None
     indexing_status: EventProcessingStatus | None = None
     cleanup_status: EventProcessingStatus | None = None

--- a/backend/supabase/migrations/015_events_description_max_participants.sql
+++ b/backend/supabase/migrations/015_events_description_max_participants.sql
@@ -1,0 +1,5 @@
+-- Add description and max_participants columns to events.
+
+alter table if exists public.events
+  add column if not exists description text,
+  add column if not exists max_participants integer;

--- a/frontend/src/app/(app)/dashboard/attendee-dashboard.tsx
+++ b/frontend/src/app/(app)/dashboard/attendee-dashboard.tsx
@@ -69,6 +69,7 @@ interface AttendeeContentProps {
   openMenuContainerRef: RefObject<HTMLDivElement | null>;
   leavingEventId: string | null;
   onToggleEventMenu: (eventId: string) => void;
+  onViewEventDetail: (event: EventResponse) => void;
   onViewRsvpList: (event: EventResponse) => void;
   onEditConsents: (event: EventResponse) => void;
   onLeaveEvent: (event: EventResponse) => void;
@@ -83,6 +84,7 @@ export function AttendeeContent({
   openMenuContainerRef,
   leavingEventId,
   onToggleEventMenu,
+  onViewEventDetail,
   onViewRsvpList,
   onEditConsents,
   onLeaveEvent,
@@ -125,7 +127,11 @@ export function AttendeeContent({
             }}
           >
             <div className="mb-2 flex items-start justify-between gap-3">
-              <div>
+              <button
+                type="button"
+                onClick={() => onViewEventDetail(event)}
+                className="min-w-0 flex-1 text-left"
+              >
                 <h2 className="text-[17px] font-medium text-white/90">{event.name}</h2>
                 <div className="mt-1 flex flex-wrap gap-2 text-[12px] text-white/45">
                   {event.starts_at ? (
@@ -141,7 +147,7 @@ export function AttendeeContent({
                     </span>
                   ) : null}
                 </div>
-              </div>
+              </button>
 
               <div
                 className="relative"

--- a/frontend/src/app/(app)/dashboard/create-event-sheet-content.tsx
+++ b/frontend/src/app/(app)/dashboard/create-event-sheet-content.tsx
@@ -9,6 +9,8 @@ export interface EventFormInput {
   starts_at?: string;
   ends_at?: string;
   location?: string;
+  description?: string;
+  max_participants?: number;
 }
 
 export type CreateEventInput = EventFormInput;
@@ -19,6 +21,8 @@ export interface EventFormInitialValues {
   starts_at?: string | null;
   ends_at?: string | null;
   location?: string | null;
+  description?: string | null;
+  max_participants?: number | null;
 }
 
 interface CreateEventSheetContentProps {
@@ -79,6 +83,8 @@ function EventFormSheetContent({
   const [endDate, setEndDate] = useState("");
   const [endTime, setEndTime] = useState("");
   const [location, setLocation] = useState("");
+  const [description, setDescription] = useState("");
+  const [maxParticipants, setMaxParticipants] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [pendingPayload, setPendingPayload] = useState<EventFormInput | null>(null);
@@ -89,6 +95,8 @@ function EventFormSheetContent({
     }
     setName(initialValues.name ?? "");
     setLocation(initialValues.location ?? "");
+    setDescription(initialValues.description ?? "");
+    setMaxParticipants(initialValues.max_participants != null ? String(initialValues.max_participants) : "");
     setStartDate(toDateInputValue(initialValues.starts_at));
     setStartTime(toTimeInputValue(initialValues.starts_at));
     setEndDate(toDateInputValue(initialValues.ends_at));
@@ -138,11 +146,15 @@ function EventFormSheetContent({
       return;
     }
 
+    const parsedMax = maxParticipants.trim() ? Number.parseInt(maxParticipants.trim(), 10) : undefined;
+
     const payload: EventFormInput = {
       name: name.trim(),
       starts_at: startsAtDate.toISOString(),
       ends_at: endsAtDate.toISOString(),
       location: location.trim() || undefined,
+      description: description.trim() || undefined,
+      max_participants: parsedMax && parsedMax > 0 ? parsedMax : undefined,
     };
 
     if (requiresConfirmation) {
@@ -164,6 +176,8 @@ function EventFormSheetContent({
         setEndDate("");
         setEndTime("");
         setLocation("");
+        setDescription("");
+        setMaxParticipants("");
       }
     } catch (submitError) {
       const message =
@@ -207,6 +221,36 @@ function EventFormSheetContent({
             value={location}
             onChange={(event) => setLocation(event.target.value)}
             placeholder="Austin Convention Center"
+            className="h-10 w-full min-w-0 max-w-full rounded-xl bg-transparent px-3 text-[16px] text-white outline-none placeholder:text-white/35"
+            style={{
+              background: "oklch(1 0 0 / 4%)",
+              border: "1px solid oklch(1 0 0 / 10%)",
+            }}
+          />
+
+          <FieldLabel htmlFor={`${mode}-event-description`}>Description</FieldLabel>
+          <textarea
+            id={`${mode}-event-description`}
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            placeholder="Tell attendees what this event is about..."
+            rows={3}
+            maxLength={2000}
+            className="w-full min-w-0 max-w-full resize-none rounded-xl bg-transparent px-3 py-2.5 text-[16px] text-white outline-none placeholder:text-white/35"
+            style={{
+              background: "oklch(1 0 0 / 4%)",
+              border: "1px solid oklch(1 0 0 / 10%)",
+            }}
+          />
+
+          <FieldLabel htmlFor={`${mode}-event-max-participants`}>Max Participants</FieldLabel>
+          <input
+            id={`${mode}-event-max-participants`}
+            type="number"
+            min="1"
+            value={maxParticipants}
+            onChange={(event) => setMaxParticipants(event.target.value)}
+            placeholder="No limit"
             className="h-10 w-full min-w-0 max-w-full rounded-xl bg-transparent px-3 text-[16px] text-white outline-none placeholder:text-white/35"
             style={{
               background: "oklch(1 0 0 / 4%)",

--- a/frontend/src/app/(app)/dashboard/discover-events-sheet-content.tsx
+++ b/frontend/src/app/(app)/dashboard/discover-events-sheet-content.tsx
@@ -16,6 +16,7 @@ interface DiscoverEventsSheetContentProps {
   onSearchTextChange: (value: string) => void;
   events: DiscoverEventItem[];
   joiningEventId: string | null;
+  onViewEventDetail: (event: EventResponse) => void;
   onJoinEvent: (event: EventResponse) => void;
 }
 
@@ -25,6 +26,7 @@ export function DiscoverEventsSheetContent({
   onSearchTextChange,
   events,
   joiningEventId,
+  onViewEventDetail,
   onJoinEvent,
 }: DiscoverEventsSheetContentProps) {
   const hasQuery = searchText.trim().length > 0;
@@ -81,7 +83,11 @@ export function DiscoverEventsSheetContent({
                   }}
                 >
                   <div className="mb-2 flex items-start justify-between gap-3">
-                    <div>
+                    <button
+                      type="button"
+                      onClick={() => onViewEventDetail(event)}
+                      className="min-w-0 flex-1 text-left"
+                    >
                       <h3 className="text-[17px] font-medium text-white/90">{event.name}</h3>
                       <div className="mt-1 flex flex-wrap gap-2 text-[12px] text-white/45">
                         {event.starts_at ? (
@@ -97,7 +103,7 @@ export function DiscoverEventsSheetContent({
                           </span>
                         ) : null}
                       </div>
-                    </div>
+                    </button>
                   </div>
 
                   <div className="mt-3">

--- a/frontend/src/app/(app)/dashboard/event-detail-sheet-content.tsx
+++ b/frontend/src/app/(app)/dashboard/event-detail-sheet-content.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { type EventResponse } from "@/lib/api";
+import { CalendarDays, Clock, MapPin, Text, Users } from "lucide-react";
+
+interface EventDetailSheetContentProps {
+  event: EventResponse;
+  formatEventDate: (value: string) => string;
+}
+
+export function EventDetailSheetContent({
+  event,
+  formatEventDate,
+}: EventDetailSheetContentProps) {
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain pr-1 pb-2">
+      <div className="space-y-5">
+        <section>
+          <h3
+            className="text-white"
+            style={{
+              fontFamily: "var(--font-serif)",
+              fontSize: 24,
+              fontWeight: 400,
+              letterSpacing: "-0.02em",
+            }}
+          >
+            {event.name}
+          </h3>
+
+          {!event.is_active ? (
+            <span
+              className="mt-2 inline-block rounded-full px-2.5 py-1 text-[10px] font-medium uppercase tracking-[0.1em]"
+              style={{
+                background: "oklch(0.3 0.06 50 / 45%)",
+                border: "1px solid oklch(0.6 0.1 50 / 30%)",
+                color: "oklch(0.85 0.06 50)",
+              }}
+            >
+              Inactive
+            </span>
+          ) : null}
+        </section>
+
+        <section className="space-y-3">
+          {event.starts_at ? (
+            <DetailRow icon={<CalendarDays className="h-4 w-4" />} label="Starts">
+              {formatEventDate(event.starts_at)}
+            </DetailRow>
+          ) : null}
+
+          {event.ends_at ? (
+            <DetailRow icon={<Clock className="h-4 w-4" />} label="Ends">
+              {formatEventDate(event.ends_at)}
+            </DetailRow>
+          ) : null}
+
+          {event.location ? (
+            <DetailRow icon={<MapPin className="h-4 w-4" />} label="Location">
+              {event.location}
+            </DetailRow>
+          ) : null}
+
+          {event.max_participants != null ? (
+            <DetailRow icon={<Users className="h-4 w-4" />} label="Max Participants">
+              {event.max_participants.toLocaleString()}
+            </DetailRow>
+          ) : null}
+        </section>
+
+        {event.description ? (
+          <section>
+            <div className="mb-2 flex items-center gap-2 text-[11px] font-medium uppercase tracking-[0.08em] text-white/50">
+              <Text className="h-3.5 w-3.5" />
+              Description
+            </div>
+            <p
+              className="whitespace-pre-wrap rounded-2xl px-4 py-3 text-[14px] leading-relaxed text-white/75"
+              style={{
+                background: "oklch(1 0 0 / 4%)",
+                border: "1px solid oklch(1 0 0 / 8%)",
+              }}
+            >
+              {event.description}
+            </p>
+          </section>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+interface DetailRowProps {
+  icon: React.ReactNode;
+  label: string;
+  children: React.ReactNode;
+}
+
+function DetailRow({ icon, label, children }: DetailRowProps) {
+  return (
+    <div className="flex items-start gap-3">
+      <div className="mt-0.5 text-white/40">{icon}</div>
+      <div>
+        <p className="text-[11px] font-medium uppercase tracking-[0.08em] text-white/45">
+          {label}
+        </p>
+        <p className="text-[15px] text-white/85">{children}</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(app)/dashboard/organizer-dashboard.tsx
+++ b/frontend/src/app/(app)/dashboard/organizer-dashboard.tsx
@@ -44,6 +44,7 @@ interface OrganizerContentProps {
   deletingEventId: string | null;
   archivingEventId: string | null;
   unarchivingEventId: string | null;
+  onViewEventDetail: (event: EventResponse) => void;
   onEditEventRequest: (event: EventResponse) => void;
   onViewRsvpList: (event: EventResponse) => void;
   onArchiveEvent: (event: EventResponse) => Promise<void>;
@@ -57,6 +58,7 @@ export function OrganizerContent({
   deletingEventId,
   archivingEventId,
   unarchivingEventId,
+  onViewEventDetail,
   onEditEventRequest,
   onViewRsvpList,
   onArchiveEvent,
@@ -166,7 +168,11 @@ export function OrganizerContent({
                 }}
               >
                 <div className="flex items-start justify-between gap-3">
-                  <div>
+                  <button
+                    type="button"
+                    onClick={() => onViewEventDetail(event)}
+                    className="min-w-0 flex-1 text-left"
+                  >
                     <h3 className="text-[17px] font-medium text-white/90">{event.name}</h3>
                     <div className="mt-1 flex flex-wrap gap-2 text-[12px] text-white/45">
                       {event.starts_at ? (
@@ -182,7 +188,7 @@ export function OrganizerContent({
                         </span>
                       ) : null}
                     </div>
-                  </div>
+                  </button>
                   <div
                     className="relative"
                     ref={openEventMenuId === event.event_id ? openMenuContainerRef : null}
@@ -266,7 +272,11 @@ export function OrganizerContent({
                 }}
               >
                 <div className="flex items-start justify-between gap-3">
-                  <div>
+                  <button
+                    type="button"
+                    onClick={() => onViewEventDetail(event)}
+                    className="min-w-0 flex-1 text-left"
+                  >
                     <h3 className="text-[17px] font-medium text-white/90">{event.name}</h3>
                     <div className="mt-1 flex flex-wrap gap-2 text-[12px] text-white/45">
                       {event.starts_at ? (
@@ -282,7 +292,7 @@ export function OrganizerContent({
                         </span>
                       ) : null}
                     </div>
-                  </div>
+                  </button>
                   <div
                     className="relative"
                     ref={openEventMenuId === event.event_id ? openMenuContainerRef : null}

--- a/frontend/src/app/(app)/dashboard/page.tsx
+++ b/frontend/src/app/(app)/dashboard/page.tsx
@@ -15,6 +15,7 @@ import { ModalBottomSheet } from "@/components/modal-bottom-sheet";
 import { ConfirmationDialog } from "@/components/confirmation-dialog";
 import { AttendeeContent, AttendeeControls, type AttendeeEventItem } from "./attendee-dashboard";
 import { DiscoverEventsSheetContent, type DiscoverEventItem } from "./discover-events-sheet-content";
+import { EventDetailSheetContent } from "./event-detail-sheet-content";
 import { OrganizerContent, OrganizerControls } from "./organizer-dashboard";
 import { RsvpListSheetContent } from "./rsvp-list-sheet-content";
 import { EventConsentsSheetContent } from "./event-consents-sheet-content";
@@ -54,6 +55,7 @@ export default function DashboardPage() {
   const [openEventMenuId, setOpenEventMenuId] = useState<string | null>(null);
   const [confirmingSignOut, setConfirmingSignOut] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [detailEvent, setDetailEvent] = useState<EventResponse | null>(null);
   const [isRsvpListOpen, setIsRsvpListOpen] = useState(false);
   const [rsvpListLoading, setRsvpListLoading] = useState(false);
   const [rsvpListEventName, setRsvpListEventName] = useState<string>("");
@@ -316,6 +318,10 @@ export default function DashboardPage() {
     }
   }
 
+  function handleViewEventDetail(event: EventResponse) {
+    setDetailEvent(event);
+  }
+
   function handleStartRecognition(event: EventResponse) {
     const params = new URLSearchParams({ event_id: event.event_id });
     router.push(`/recognition?${params.toString()}`);
@@ -534,6 +540,7 @@ export default function DashboardPage() {
             deletingEventId={deletingOrganizedEventId}
             archivingEventId={archivingOrganizedEventId}
             unarchivingEventId={unarchivingOrganizedEventId}
+            onViewEventDetail={handleViewEventDetail}
             onEditEventRequest={handleEditEventRequest}
             onViewRsvpList={(event) => void handleViewRsvpList(event)}
             onArchiveEvent={handleArchiveOrganizedEvent}
@@ -550,6 +557,7 @@ export default function DashboardPage() {
             onToggleEventMenu={(eventId) =>
               setOpenEventMenuId((current) => (current === eventId ? null : eventId))
             }
+            onViewEventDetail={handleViewEventDetail}
             onViewRsvpList={(event) => void handleViewRsvpList(event)}
             onEditConsents={(event) => void handleEditConsents(event)}
             onLeaveEvent={(event) => {
@@ -602,6 +610,7 @@ export default function DashboardPage() {
           onSearchTextChange={setDiscoverSearchText}
           events={discoveredUpcomingEvents}
           joiningEventId={joiningDiscoverEventId}
+          onViewEventDetail={handleViewEventDetail}
           onJoinEvent={handleJoinDiscoverEvent}
         />
       </ModalBottomSheet>
@@ -635,6 +644,19 @@ export default function DashboardPage() {
             isSubmitting={updatingEvent}
             initialValues={editingEvent}
             onSubmit={handleUpdateEvent}
+          />
+        ) : null}
+      </ModalBottomSheet>
+
+      <ModalBottomSheet
+        isOpen={Boolean(detailEvent)}
+        onClose={() => setDetailEvent(null)}
+        title="Event Details"
+      >
+        {detailEvent ? (
+          <EventDetailSheetContent
+            event={detailEvent}
+            formatEventDate={formatEventDate}
           />
         ) : null}
       </ModalBottomSheet>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -216,6 +216,8 @@ export interface EventCreateRequest {
   starts_at?: string;
   ends_at?: string;
   location?: string;
+  description?: string;
+  max_participants?: number;
   is_active?: boolean;
 }
 
@@ -224,6 +226,8 @@ export interface EventUpdateRequest {
   starts_at?: string;
   ends_at?: string;
   location?: string;
+  description?: string;
+  max_participants?: number;
   is_active?: boolean;
 }
 
@@ -296,6 +300,8 @@ export interface EventResponse {
   starts_at: string | null;
   ends_at: string | null;
   location: string | null;
+  description: string | null;
+  max_participants: number | null;
   is_active: boolean;
   indexing_status: "pending" | "in_progress" | "completed" | "failed";
   cleanup_status: "pending" | "in_progress" | "completed" | "failed";


### PR DESCRIPTION
## Summary
- Create new EventDetailSheetContent component that displays full event details (name, start/end dates, location, description, max participants) in a bottom sheet
- Make event card titles clickable across all three views: attendee events, organizer events (active + inactive), and discover events
- Wire up the detail sheet modal in the main dashboard page
- Depends on PR #264 for the description and max_participants fields

## Test Plan
- [ ] Click an event card in the attendee tab — detail sheet opens with correct info
- [ ] Click an event card in the organizer tab (active and inactive) — detail sheet opens
- [ ] Click an event card in the discover events sheet — detail sheet opens
- [ ] Verify the overflow menu (⋯) and action buttons still work independently of the card click
- [ ] Swipe down or tap close to dismiss the detail sheet
- [ ] Events with no description or max participants show cleanly without empty sections

Closes #265 