### PR TITLE
Feature/profile likes

### DIFF
--- a/backend/app/api/profiles.py
+++ b/backend/app/api/profiles.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
+from postgrest.exceptions import APIError
 from pydantic import BaseModel
 
 from app.auth import CurrentUser, get_current_user
@@ -22,6 +23,8 @@ from app.schemas import (
     ProfileCompletionResponse,
     ProfileCreate,
     ProfileDirectoryResponse,
+    ProfileLikeCreateRequest,
+    ProfileLikeResponse,
     ProfileResponse,
     ProfileUpdate,
 )
@@ -274,6 +277,89 @@ async def delete_my_profile(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Profile not found.",
+        )
+
+
+@router.get("/me/likes", response_model=list[ProfileLikeResponse])
+async def get_my_profile_likes(
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    dal: Annotated[ProfileDAL, Depends(get_profile_dal)],
+) -> list[ProfileLikeResponse]:
+    """Get all profiles liked by the current user."""
+    return await dal.get_user_profile_likes(user_id=current_user.id)
+
+
+@router.post(
+    "/{user_id}/like",
+    response_model=ProfileLikeResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def like_profile(
+    user_id: UUID,
+    data: ProfileLikeCreateRequest,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    profile_dal: Annotated[ProfileDAL, Depends(get_profile_dal)],
+    event_dal: Annotated[EventDAL, Depends(get_event_dal)],
+    membership_dal: Annotated[MembershipDAL, Depends(get_membership_dal)],
+) -> ProfileLikeResponse:
+    """Like another user's profile for a specific event where users met."""
+    if user_id == current_user.id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="You cannot like your own profile.",
+        )
+
+    event = await event_dal.get_by_id(data.event_id)
+    if not event:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Event not found.",
+        )
+
+    membership = await membership_dal.get(event_id=data.event_id, user_id=current_user.id)
+    if membership is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You are not a member of this event.",
+        )
+
+    target_profile = await profile_dal.get_by_user_id(user_id)
+    if target_profile is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Profile not found or not visible.",
+        )
+
+    try:
+        return await profile_dal.create_profile_like(
+            user_id=current_user.id,
+            liked_profile_id=user_id,
+            event_id=data.event_id,
+        )
+    except APIError as exc:
+        if str(exc.code) == "23505":
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Profile already liked for this event.",
+            ) from exc
+        raise
+
+
+@router.delete("/{user_id}/like", status_code=status.HTTP_204_NO_CONTENT)
+async def unlike_profile(
+    user_id: UUID,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    profile_dal: Annotated[ProfileDAL, Depends(get_profile_dal)],
+) -> None:
+    """Remove a profile like."""
+    deleted = await profile_dal.delete_profile_like(
+        user_id=current_user.id,
+        liked_profile_id=user_id,
+    )
+    if not deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Like not found.",
         )
 
 

--- a/backend/app/dals/profile_dal.py
+++ b/backend/app/dals/profile_dal.py
@@ -158,7 +158,36 @@ class ProfileDAL(BaseDAL):
             .order("created_at", desc=True)
             .execute()
         )
-        return [ProfileLikeResponse(**row) for row in response.data]
+        rows: list[dict[str, Any]] = response.data or []
+
+        event_names_by_id: dict[str, str | None] = {}
+
+        likes: list[ProfileLikeResponse] = []
+        for row in rows:
+            event_id = row.get("event_id")
+            event_name: str | None = None
+
+            if event_id is not None:
+                event_id_str = str(event_id)
+                if event_id_str in event_names_by_id:
+                    event_name = event_names_by_id[event_id_str]
+                else:
+                    event_response = (
+                        self.client.table("events")
+                        .select("event_id,name")
+                        .eq("event_id", event_id_str)
+                        .maybe_single()
+                        .execute()
+                    )
+                    event_name = (
+                        event_response.data.get("name")
+                        if event_response and event_response.data
+                        else None
+                    )
+                    event_names_by_id[event_id_str] = event_name
+
+            likes.append(ProfileLikeResponse(**row, event_name=event_name))
+        return likes
 
     async def delete_profile_like(
         self,

--- a/backend/app/dals/profile_dal.py
+++ b/backend/app/dals/profile_dal.py
@@ -153,38 +153,23 @@ class ProfileDAL(BaseDAL):
         """List all profile likes created by a user."""
         response = (
             self.client.table(self.PROFILE_LIKES_TABLE)
-            .select("*")
+            .select(
+                "user_id,liked_profile_id,event_id,created_at,event:events(name)",
+            )
             .eq("user_id", str(user_id))
             .order("created_at", desc=True)
             .execute()
         )
         rows: list[dict[str, Any]] = response.data or []
 
-        event_names_by_id: dict[str, str | None] = {}
-
         likes: list[ProfileLikeResponse] = []
         for row in rows:
-            event_id = row.get("event_id")
+            event_data = row.pop("event", None)
             event_name: str | None = None
-
-            if event_id is not None:
-                event_id_str = str(event_id)
-                if event_id_str in event_names_by_id:
-                    event_name = event_names_by_id[event_id_str]
-                else:
-                    event_response = (
-                        self.client.table("events")
-                        .select("event_id,name")
-                        .eq("event_id", event_id_str)
-                        .maybe_single()
-                        .execute()
-                    )
-                    event_name = (
-                        event_response.data.get("name")
-                        if event_response and event_response.data
-                        else None
-                    )
-                    event_names_by_id[event_id_str] = event_name
+            if isinstance(event_data, dict):
+                event_name_raw = event_data.get("name")
+                if isinstance(event_name_raw, str):
+                    event_name = event_name_raw
 
             likes.append(ProfileLikeResponse(**row, event_name=event_name))
         return likes

--- a/backend/app/dals/profile_dal.py
+++ b/backend/app/dals/profile_dal.py
@@ -154,7 +154,10 @@ class ProfileDAL(BaseDAL):
         response = (
             self.client.table(self.PROFILE_LIKES_TABLE)
             .select(
-                "user_id,liked_profile_id,event_id,created_at,event:events(name)",
+                (
+                    "user_id,liked_profile_id,event_id,created_at,"
+                    "event:events(name),liked_profile:profiles(*)"
+                ),
             )
             .eq("user_id", str(user_id))
             .order("created_at", desc=True)
@@ -165,13 +168,20 @@ class ProfileDAL(BaseDAL):
         likes: list[ProfileLikeResponse] = []
         for row in rows:
             event_data = row.pop("event", None)
+            liked_profile = row.pop("liked_profile", None)
             event_name: str | None = None
             if isinstance(event_data, dict):
                 event_name_raw = event_data.get("name")
                 if isinstance(event_name_raw, str):
                     event_name = event_name_raw
 
-            likes.append(ProfileLikeResponse(**row, event_name=event_name))
+            likes.append(
+                ProfileLikeResponse(
+                    **row,
+                    event_name=event_name,
+                    liked_profile=liked_profile if isinstance(liked_profile, dict) else None,
+                )
+            )
         return likes
 
     async def delete_profile_like(

--- a/backend/app/dals/profile_dal.py
+++ b/backend/app/dals/profile_dal.py
@@ -11,6 +11,7 @@ from app.dals.base_dal import BaseDAL
 from app.schemas import (
     ProfileCreate,
     ProfileDirectoryEntry,
+    ProfileLikeResponse,
     ProfileResponse,
     ProfileUpdate,
 )
@@ -21,6 +22,7 @@ class ProfileDAL(BaseDAL):
     """DAL for profile operations."""
 
     TABLE = "profiles"
+    PROFILE_LIKES_TABLE = "profile_likes"
 
     def __init__(self, client: Client):
         super().__init__(client)
@@ -130,6 +132,49 @@ class ProfileDAL(BaseDAL):
         if response.data:
             return ProfileResponse(**response.data[0])
         return None
+
+    async def create_profile_like(
+        self,
+        *,
+        user_id: UUID,
+        liked_profile_id: UUID,
+        event_id: UUID,
+    ) -> ProfileLikeResponse:
+        """Create a profile-like row."""
+        insert_data = {
+            "user_id": str(user_id),
+            "liked_profile_id": str(liked_profile_id),
+            "event_id": str(event_id),
+        }
+        response = self.client.table(self.PROFILE_LIKES_TABLE).insert(insert_data).execute()
+        return ProfileLikeResponse(**response.data[0])
+
+    async def get_user_profile_likes(self, *, user_id: UUID) -> list[ProfileLikeResponse]:
+        """List all profile likes created by a user."""
+        response = (
+            self.client.table(self.PROFILE_LIKES_TABLE)
+            .select("*")
+            .eq("user_id", str(user_id))
+            .order("created_at", desc=True)
+            .execute()
+        )
+        return [ProfileLikeResponse(**row) for row in response.data]
+
+    async def delete_profile_like(
+        self,
+        *,
+        user_id: UUID,
+        liked_profile_id: UUID,
+    ) -> bool:
+        """Delete a profile-like row."""
+        response = (
+            self.client.table(self.PROFILE_LIKES_TABLE)
+            .delete()
+            .eq("user_id", str(user_id))
+            .eq("liked_profile_id", str(liked_profile_id))
+            .execute()
+        )
+        return len(response.data) > 0
 
 
 def _extract_current_school(education: Any) -> str | None:

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -31,6 +31,8 @@ from .profile import (
     ProfileCreate,
     ProfileDirectoryEntry,
     ProfileDirectoryResponse,
+    ProfileLikeCreateRequest,
+    ProfileLikeResponse,
     ProfileResponse,
     ProfileUpdate,
 )
@@ -69,6 +71,8 @@ __all__ = [
     "ProfileCreate",
     "ProfileDirectoryEntry",
     "ProfileDirectoryResponse",
+    "ProfileLikeCreateRequest",
+    "ProfileLikeResponse",
     "ProfileResponse",
     "ProfileUpdate",
     # Recognition

--- a/backend/app/schemas/profile.py
+++ b/backend/app/schemas/profile.py
@@ -97,4 +97,5 @@ class ProfileLikeResponse(BaseModel):
     user_id: UUID
     liked_profile_id: UUID
     event_id: UUID | None
+    event_name: str | None = None
     created_at: datetime

--- a/backend/app/schemas/profile.py
+++ b/backend/app/schemas/profile.py
@@ -81,3 +81,20 @@ class ProfileDirectoryResponse(BaseModel):
     entries: list[ProfileDirectoryEntry]
     total_count: int
     hidden_count: int
+
+
+class ProfileLikeCreateRequest(BaseModel):
+    """Request payload for liking a profile in the context of an event."""
+
+    event_id: UUID
+
+
+class ProfileLikeResponse(BaseModel):
+    """Schema for profile-like rows."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    user_id: UUID
+    liked_profile_id: UUID
+    event_id: UUID
+    created_at: datetime

--- a/backend/app/schemas/profile.py
+++ b/backend/app/schemas/profile.py
@@ -99,6 +99,7 @@ class ProfileLikeResponse(BaseModel):
     liked_profile_id: UUID
     event_id: UUID | None
     event_name: str | None = None
+    liked_profile: ProfileResponse | None = None
     created_at: datetime
 
 

--- a/backend/app/schemas/profile.py
+++ b/backend/app/schemas/profile.py
@@ -96,5 +96,5 @@ class ProfileLikeResponse(BaseModel):
 
     user_id: UUID
     liked_profile_id: UUID
-    event_id: UUID
+    event_id: UUID | None
     created_at: datetime

--- a/backend/supabase/migrations/015_events_description_max_participants.sql
+++ b/backend/supabase/migrations/015_events_description_max_participants.sql
@@ -1,5 +1,0 @@
--- Add description and max_participants columns to events.
-
-alter table if exists public.events
-  add column if not exists description text,
-  add column if not exists max_participants integer;

--- a/backend/supabase/migrations/015_profile_likes.sql
+++ b/backend/supabase/migrations/015_profile_likes.sql
@@ -4,7 +4,7 @@
 create table if not exists public.profile_likes (
   user_id uuid not null references auth.users(id) on delete cascade,
   liked_profile_id uuid not null references public.profiles(user_id) on delete cascade,
-  event_id uuid not null references public.events(event_id) on delete cascade,
+  event_id uuid references public.events(event_id) on delete set null,
   created_at timestamptz not null default now(),
   primary key (user_id, liked_profile_id),
   check (user_id <> liked_profile_id)

--- a/backend/supabase/migrations/015_profile_likes.sql
+++ b/backend/supabase/migrations/015_profile_likes.sql
@@ -6,7 +6,7 @@ create table if not exists public.profile_likes (
   liked_profile_id uuid not null references public.profiles(user_id) on delete cascade,
   event_id uuid not null references public.events(event_id) on delete cascade,
   created_at timestamptz not null default now(),
-  primary key (user_id, liked_profile_id, event_id),
+  primary key (user_id, liked_profile_id),
   check (user_id <> liked_profile_id)
 );
 

--- a/backend/supabase/migrations/015_profile_likes.sql
+++ b/backend/supabase/migrations/015_profile_likes.sql
@@ -4,10 +4,15 @@
 create table if not exists public.profile_likes (
   user_id uuid not null references auth.users(id) on delete cascade,
   liked_profile_id uuid not null references public.profiles(user_id) on delete cascade,
+  event_id uuid not null references public.events(event_id) on delete cascade,
   created_at timestamptz not null default now(),
-  primary key (user_id, liked_profile_id),
+  primary key (user_id, liked_profile_id, event_id),
   check (user_id <> liked_profile_id)
 );
+
+-- Supports user-centric reads scoped to where users met.
+create index if not exists idx_profile_likes_user_event
+  on public.profile_likes(user_id, event_id);
 
 -- Supports reverse lookups such as "who liked this profile".
 create index if not exists idx_profile_likes_liked_profile_id

--- a/backend/supabase/migrations/015_profile_likes.sql
+++ b/backend/supabase/migrations/015_profile_likes.sql
@@ -1,0 +1,37 @@
+-- Track which profiles a user has liked.
+-- Query pattern optimized for: "get all liked profiles for current user".
+
+create table if not exists public.profile_likes (
+  user_id uuid not null references auth.users(id) on delete cascade,
+  liked_profile_id uuid not null references public.profiles(user_id) on delete cascade,
+  created_at timestamptz not null default now(),
+  primary key (user_id, liked_profile_id),
+  check (user_id <> liked_profile_id)
+);
+
+-- Supports reverse lookups such as "who liked this profile".
+create index if not exists idx_profile_likes_liked_profile_id
+  on public.profile_likes(liked_profile_id);
+
+alter table public.profile_likes enable row level security;
+
+drop policy if exists "profile_likes_select_own" on public.profile_likes;
+create policy "profile_likes_select_own"
+on public.profile_likes
+for select
+to authenticated
+using (auth.uid() = user_id);
+
+drop policy if exists "profile_likes_insert_own" on public.profile_likes;
+create policy "profile_likes_insert_own"
+on public.profile_likes
+for insert
+to authenticated
+with check (auth.uid() = user_id);
+
+drop policy if exists "profile_likes_delete_own" on public.profile_likes;
+create policy "profile_likes_delete_own"
+on public.profile_likes
+for delete
+to authenticated
+using (auth.uid() = user_id);

--- a/backend/tests/test_profile_likes.py
+++ b/backend/tests/test_profile_likes.py
@@ -19,7 +19,7 @@ from app.api.profiles import (  # noqa: E402
 )
 from app.auth import CurrentUser, get_current_user  # noqa: E402
 from app.main import app  # noqa: E402
-from app.schemas.profile import ProfileLikeResponse  # noqa: E402
+from app.schemas.profile import ProfileLikeResponse, ProfileResponse  # noqa: E402
 
 
 @pytest.fixture
@@ -41,7 +41,31 @@ def _like(user_id: UUID, liked_profile_id: UUID, event_id: UUID | None) -> Profi
         liked_profile_id=liked_profile_id,
         event_id=event_id,
         event_name="Spring Summit" if event_id else None,
+        liked_profile=_profile(liked_profile_id),
         created_at=datetime.now(timezone.utc),
+    )
+
+
+def _profile(user_id: UUID) -> ProfileResponse:
+    return ProfileResponse(
+        user_id=user_id,
+        full_name="Liked User",
+        headline="Software Engineer",
+        bio=None,
+        location=None,
+        company=None,
+        major=None,
+        graduation_year=None,
+        linkedin_url=None,
+        photo_path=None,
+        experiences=[],
+        education=[],
+        profile_one_liner=None,
+        profile_summary=None,
+        summary_provider=None,
+        summary_updated_at=None,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
     )
 
 
@@ -72,9 +96,12 @@ def test_get_my_profile_likes_returns_rows(client: TestClient):
     assert body[0]["liked_profile_id"] == str(liked_a)
     assert body[0]["event_id"] == str(event_id)
     assert body[0]["event_name"] == "Spring Summit"
+    assert body[0]["liked_profile"]["user_id"] == str(liked_a)
+    assert body[0]["liked_profile"]["full_name"] == "Liked User"
     assert body[1]["liked_profile_id"] == str(liked_b)
     assert body[1]["event_id"] is None
     assert body[1]["event_name"] is None
+    assert body[1]["liked_profile"]["user_id"] == str(liked_b)
     profile_dal.get_user_profile_likes.assert_awaited_once_with(user_id=user_id)
 
 

--- a/backend/tests/test_profile_likes.py
+++ b/backend/tests/test_profile_likes.py
@@ -1,0 +1,308 @@
+"""Tests for profile-like endpoints under /api/v1/profiles."""
+
+import os
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+from postgrest.exceptions import APIError
+
+os.environ["DEBUG"] = "false"
+
+from app.api.profiles import (  # noqa: E402
+    get_event_dal,
+    get_membership_dal,
+    get_profile_dal,
+)
+from app.auth import CurrentUser, get_current_user  # noqa: E402
+from app.main import app  # noqa: E402
+from app.schemas.profile import ProfileLikeResponse  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    """Create a test client and isolate dependency overrides per test."""
+    app.dependency_overrides.clear()
+    with TestClient(app) as test_client:
+        yield test_client
+    app.dependency_overrides.clear()
+
+
+def _mock_user(user_id: UUID) -> CurrentUser:
+    return CurrentUser(id=user_id, email="test@example.com", access_token="test-token")
+
+
+def _like(user_id: UUID, liked_profile_id: UUID, event_id: UUID | None) -> ProfileLikeResponse:
+    return ProfileLikeResponse(
+        user_id=user_id,
+        liked_profile_id=liked_profile_id,
+        event_id=event_id,
+        event_name="Spring Summit" if event_id else None,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+def test_get_my_profile_likes_returns_rows(client: TestClient):
+    user_id = uuid4()
+    liked_a = uuid4()
+    liked_b = uuid4()
+    event_id = uuid4()
+
+    profile_dal = SimpleNamespace(
+        get_user_profile_likes=AsyncMock(
+            return_value=[
+                _like(user_id, liked_a, event_id),
+                _like(user_id, liked_b, None),
+            ]
+        )
+    )
+
+    app.dependency_overrides[get_current_user] = lambda: _mock_user(user_id)
+    app.dependency_overrides[get_profile_dal] = lambda: profile_dal
+
+    response = client.get("/api/v1/profiles/me/likes")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body) == 2
+    assert body[0]["user_id"] == str(user_id)
+    assert body[0]["liked_profile_id"] == str(liked_a)
+    assert body[0]["event_id"] == str(event_id)
+    assert body[0]["event_name"] == "Spring Summit"
+    assert body[1]["liked_profile_id"] == str(liked_b)
+    assert body[1]["event_id"] is None
+    assert body[1]["event_name"] is None
+    profile_dal.get_user_profile_likes.assert_awaited_once_with(user_id=user_id)
+
+
+def test_like_profile_returns_400_for_self_like(client: TestClient):
+    user_id = uuid4()
+    event_id = uuid4()
+
+    profile_dal = SimpleNamespace(
+        get_by_user_id=AsyncMock(),
+        create_profile_like=AsyncMock(),
+    )
+    event_dal = SimpleNamespace(get_by_id=AsyncMock())
+    membership_dal = SimpleNamespace(get=AsyncMock())
+
+    app.dependency_overrides[get_current_user] = lambda: _mock_user(user_id)
+    app.dependency_overrides[get_profile_dal] = lambda: profile_dal
+    app.dependency_overrides[get_event_dal] = lambda: event_dal
+    app.dependency_overrides[get_membership_dal] = lambda: membership_dal
+
+    response = client.post(f"/api/v1/profiles/{user_id}/like", json={"event_id": str(event_id)})
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "You cannot like your own profile."
+    event_dal.get_by_id.assert_not_awaited()
+    membership_dal.get.assert_not_awaited()
+    profile_dal.get_by_user_id.assert_not_awaited()
+    profile_dal.create_profile_like.assert_not_awaited()
+
+
+def test_like_profile_returns_404_when_event_not_found(client: TestClient):
+    user_id = uuid4()
+    target_user_id = uuid4()
+    event_id = uuid4()
+
+    profile_dal = SimpleNamespace(
+        get_by_user_id=AsyncMock(),
+        create_profile_like=AsyncMock(),
+    )
+    event_dal = SimpleNamespace(get_by_id=AsyncMock(return_value=None))
+    membership_dal = SimpleNamespace(get=AsyncMock())
+
+    app.dependency_overrides[get_current_user] = lambda: _mock_user(user_id)
+    app.dependency_overrides[get_profile_dal] = lambda: profile_dal
+    app.dependency_overrides[get_event_dal] = lambda: event_dal
+    app.dependency_overrides[get_membership_dal] = lambda: membership_dal
+
+    response = client.post(
+        f"/api/v1/profiles/{target_user_id}/like", json={"event_id": str(event_id)}
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Event not found."
+    membership_dal.get.assert_not_awaited()
+    profile_dal.get_by_user_id.assert_not_awaited()
+    profile_dal.create_profile_like.assert_not_awaited()
+
+
+def test_like_profile_returns_403_when_user_not_event_member(client: TestClient):
+    user_id = uuid4()
+    target_user_id = uuid4()
+    event_id = uuid4()
+
+    profile_dal = SimpleNamespace(
+        get_by_user_id=AsyncMock(),
+        create_profile_like=AsyncMock(),
+    )
+    event_dal = SimpleNamespace(
+        get_by_id=AsyncMock(return_value=SimpleNamespace(event_id=event_id))
+    )
+    membership_dal = SimpleNamespace(get=AsyncMock(return_value=None))
+
+    app.dependency_overrides[get_current_user] = lambda: _mock_user(user_id)
+    app.dependency_overrides[get_profile_dal] = lambda: profile_dal
+    app.dependency_overrides[get_event_dal] = lambda: event_dal
+    app.dependency_overrides[get_membership_dal] = lambda: membership_dal
+
+    response = client.post(
+        f"/api/v1/profiles/{target_user_id}/like", json={"event_id": str(event_id)}
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "You are not a member of this event."
+    membership_dal.get.assert_awaited_once_with(event_id=event_id, user_id=user_id)
+    profile_dal.get_by_user_id.assert_not_awaited()
+    profile_dal.create_profile_like.assert_not_awaited()
+
+
+def test_like_profile_returns_404_when_target_profile_not_visible(client: TestClient):
+    user_id = uuid4()
+    target_user_id = uuid4()
+    event_id = uuid4()
+
+    profile_dal = SimpleNamespace(
+        get_by_user_id=AsyncMock(return_value=None),
+        create_profile_like=AsyncMock(),
+    )
+    event_dal = SimpleNamespace(
+        get_by_id=AsyncMock(return_value=SimpleNamespace(event_id=event_id))
+    )
+    membership_dal = SimpleNamespace(
+        get=AsyncMock(return_value=SimpleNamespace(event_id=event_id, user_id=user_id))
+    )
+
+    app.dependency_overrides[get_current_user] = lambda: _mock_user(user_id)
+    app.dependency_overrides[get_profile_dal] = lambda: profile_dal
+    app.dependency_overrides[get_event_dal] = lambda: event_dal
+    app.dependency_overrides[get_membership_dal] = lambda: membership_dal
+
+    response = client.post(
+        f"/api/v1/profiles/{target_user_id}/like", json={"event_id": str(event_id)}
+    )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Profile not found or not visible."
+    profile_dal.get_by_user_id.assert_awaited_once_with(target_user_id)
+    profile_dal.create_profile_like.assert_not_awaited()
+
+
+def test_like_profile_returns_201_on_success(client: TestClient):
+    user_id = uuid4()
+    target_user_id = uuid4()
+    event_id = uuid4()
+    created_like = _like(user_id, target_user_id, event_id)
+
+    profile_dal = SimpleNamespace(
+        get_by_user_id=AsyncMock(return_value=SimpleNamespace(user_id=target_user_id)),
+        create_profile_like=AsyncMock(return_value=created_like),
+    )
+    event_dal = SimpleNamespace(
+        get_by_id=AsyncMock(return_value=SimpleNamespace(event_id=event_id))
+    )
+    membership_dal = SimpleNamespace(
+        get=AsyncMock(return_value=SimpleNamespace(event_id=event_id, user_id=user_id))
+    )
+
+    app.dependency_overrides[get_current_user] = lambda: _mock_user(user_id)
+    app.dependency_overrides[get_profile_dal] = lambda: profile_dal
+    app.dependency_overrides[get_event_dal] = lambda: event_dal
+    app.dependency_overrides[get_membership_dal] = lambda: membership_dal
+
+    response = client.post(
+        f"/api/v1/profiles/{target_user_id}/like", json={"event_id": str(event_id)}
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["user_id"] == str(user_id)
+    assert body["liked_profile_id"] == str(target_user_id)
+    assert body["event_id"] == str(event_id)
+    profile_dal.create_profile_like.assert_awaited_once_with(
+        user_id=user_id,
+        liked_profile_id=target_user_id,
+        event_id=event_id,
+    )
+
+
+def test_like_profile_returns_409_on_duplicate(client: TestClient):
+    user_id = uuid4()
+    target_user_id = uuid4()
+    event_id = uuid4()
+
+    duplicate_error = APIError(
+        {
+            "code": "23505",
+            "message": "duplicate key value violates unique constraint",
+            "details": "",
+            "hint": "",
+        }
+    )
+
+    profile_dal = SimpleNamespace(
+        get_by_user_id=AsyncMock(return_value=SimpleNamespace(user_id=target_user_id)),
+        create_profile_like=AsyncMock(side_effect=duplicate_error),
+    )
+    event_dal = SimpleNamespace(
+        get_by_id=AsyncMock(return_value=SimpleNamespace(event_id=event_id))
+    )
+    membership_dal = SimpleNamespace(
+        get=AsyncMock(return_value=SimpleNamespace(event_id=event_id, user_id=user_id))
+    )
+
+    app.dependency_overrides[get_current_user] = lambda: _mock_user(user_id)
+    app.dependency_overrides[get_profile_dal] = lambda: profile_dal
+    app.dependency_overrides[get_event_dal] = lambda: event_dal
+    app.dependency_overrides[get_membership_dal] = lambda: membership_dal
+
+    response = client.post(
+        f"/api/v1/profiles/{target_user_id}/like", json={"event_id": str(event_id)}
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "Profile already liked for this event."
+
+
+def test_unlike_profile_returns_204_on_success(client: TestClient):
+    user_id = uuid4()
+    target_user_id = uuid4()
+    profile_dal = SimpleNamespace(
+        delete_profile_like=AsyncMock(return_value=True),
+    )
+
+    app.dependency_overrides[get_current_user] = lambda: _mock_user(user_id)
+    app.dependency_overrides[get_profile_dal] = lambda: profile_dal
+
+    response = client.delete(f"/api/v1/profiles/{target_user_id}/like")
+
+    assert response.status_code == 204
+    profile_dal.delete_profile_like.assert_awaited_once_with(
+        user_id=user_id,
+        liked_profile_id=target_user_id,
+    )
+
+
+def test_unlike_profile_returns_404_when_not_found(client: TestClient):
+    user_id = uuid4()
+    target_user_id = uuid4()
+    profile_dal = SimpleNamespace(
+        delete_profile_like=AsyncMock(return_value=False),
+    )
+
+    app.dependency_overrides[get_current_user] = lambda: _mock_user(user_id)
+    app.dependency_overrides[get_profile_dal] = lambda: profile_dal
+
+    response = client.delete(f"/api/v1/profiles/{target_user_id}/like")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Like not found."
+    profile_dal.delete_profile_like.assert_awaited_once_with(
+        user_id=user_id,
+        liked_profile_id=target_user_id,
+    )

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -142,7 +142,6 @@
       "version": "7.29.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -594,7 +593,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -639,7 +637,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -780,7 +777,6 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -826,6 +822,28 @@
       },
       "peerDependencies": {
         "@noble/ciphers": "^1.0.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1880,7 +1898,6 @@
       "version": "1.3.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3738,7 +3755,6 @@
     "node_modules/@supabase/supabase-js": {
       "version": "2.103.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.103.3",
         "@supabase/functions-js": "2.103.3",
@@ -4181,7 +4197,8 @@
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -4223,7 +4240,6 @@
       "version": "19.2.14",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4232,7 +4248,6 @@
       "version": "19.2.3",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4301,7 +4316,6 @@
       "version": "8.58.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.2",
         "@typescript-eslint/types": "8.58.2",
@@ -4945,7 +4959,6 @@
       "version": "8.16.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5363,7 +5376,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5993,7 +6005,8 @@
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dotenv": {
       "version": "17.4.2",
@@ -6291,7 +6304,6 @@
       "version": "9.39.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6461,7 +6473,6 @@
       "version": "2.32.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7413,7 +7424,6 @@
       "version": "4.12.14",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8643,6 +8653,7 @@
       "version": "1.5.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -9506,6 +9517,7 @@
       "version": "27.5.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -9519,6 +9531,7 @@
       "version": "5.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9728,7 +9741,6 @@
     "node_modules/react": {
       "version": "19.2.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9736,7 +9748,6 @@
     "node_modules/react-dom": {
       "version": "19.2.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9747,7 +9758,8 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
@@ -10890,7 +10902,6 @@
       "version": "4.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11129,7 +11140,6 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11365,7 +11375,6 @@
       "version": "8.0.8",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -11918,7 +11927,6 @@
       "version": "4.3.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/app/(app)/favorites/__tests__/favorites-page.test.tsx
+++ b/frontend/src/app/(app)/favorites/__tests__/favorites-page.test.tsx
@@ -1,0 +1,166 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  mockPush,
+  resetNavigationMocks,
+} from "@/test/mocks/next-navigation";
+import {
+  resetSupabaseMocks,
+  mockSessionWith,
+  mockNoSession,
+} from "@/test/mocks/supabase";
+
+const mockGetMyProfileLikes = vi.fn();
+const mockUnlikeProfile = vi.fn();
+const mockLikeProfile = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    setToken: vi.fn(),
+    getMyProfileLikes: (...args: unknown[]) => mockGetMyProfileLikes(...args),
+    unlikeProfile: (...args: unknown[]) => mockUnlikeProfile(...args),
+    likeProfile: (...args: unknown[]) => mockLikeProfile(...args),
+  },
+  isApiErrorWithStatus: () => false,
+}));
+
+vi.mock("@/components/aurora", () => ({
+  Aurora: () => <div data-testid="aurora" />,
+}));
+
+import FavoritesPage from "../page";
+
+const MOCK_LIKES = [
+  {
+    user_id: "viewer-1",
+    liked_profile_id: "liked-1",
+    event_id: "evt-1",
+    event_name: "AI Mixer",
+    liked_profile: {
+      user_id: "liked-1",
+      full_name: "Sarah Chen",
+      headline: "ML Engineer",
+      bio: null,
+      location: null,
+      company: null,
+      major: null,
+      graduation_year: null,
+      linkedin_url: null,
+      photo_path: null,
+      experiences: [],
+      education: [],
+      profile_one_liner: null,
+      profile_summary: null,
+    },
+    created_at: new Date().toISOString(),
+  },
+  {
+    user_id: "viewer-1",
+    liked_profile_id: "liked-2",
+    event_id: null,
+    event_name: null,
+    liked_profile: {
+      user_id: "liked-2",
+      full_name: "Alex Patel",
+      headline: "Product Designer",
+      bio: null,
+      location: null,
+      company: null,
+      major: null,
+      graduation_year: null,
+      linkedin_url: null,
+      photo_path: null,
+      experiences: [],
+      education: [],
+      profile_one_liner: null,
+      profile_summary: null,
+    },
+    created_at: new Date().toISOString(),
+  },
+];
+
+describe("FavoritesPage", () => {
+  beforeEach(() => {
+    resetNavigationMocks();
+    resetSupabaseMocks();
+    mockGetMyProfileLikes.mockReset();
+    mockUnlikeProfile.mockReset();
+    mockLikeProfile.mockReset();
+    mockSessionWith();
+  });
+
+  it("redirects to login when no session", async () => {
+    mockNoSession();
+    mockGetMyProfileLikes.mockResolvedValue([]);
+
+    render(<FavoritesPage />);
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/login");
+    });
+  });
+
+  it("renders favorite cards from /me/likes response", async () => {
+    mockGetMyProfileLikes.mockResolvedValue(MOCK_LIKES);
+
+    render(<FavoritesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Sarah Chen")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Alex Patel")).toBeInTheDocument();
+    expect(screen.getByText("Met at: AI Mixer")).toBeInTheDocument();
+    expect(screen.getByText("Met at: Unknown event")).toBeInTheDocument();
+  });
+
+  it("filters favorites by search query", async () => {
+    mockGetMyProfileLikes.mockResolvedValue(MOCK_LIKES);
+
+    render(<FavoritesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Sarah Chen")).toBeInTheDocument();
+    });
+
+    await userEvent.type(screen.getByPlaceholderText("Search favorites"), "alex");
+    expect(screen.queryByText("Sarah Chen")).not.toBeInTheDocument();
+    expect(screen.getByText("Alex Patel")).toBeInTheDocument();
+  });
+
+  it("navigates to profile details with source=favorites and event_id", async () => {
+    mockGetMyProfileLikes.mockResolvedValue([MOCK_LIKES[0]]);
+
+    render(<FavoritesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Sarah Chen")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText("Sarah Chen"));
+    expect(mockPush).toHaveBeenCalledWith("/profile/liked-1?event_id=evt-1&source=favorites");
+  });
+
+  it("shows confirmation dialog before unliking from favorites", async () => {
+    mockGetMyProfileLikes.mockResolvedValue([MOCK_LIKES[0]]);
+    mockUnlikeProfile.mockResolvedValue(undefined);
+
+    render(<FavoritesPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Sarah Chen")).toBeInTheDocument();
+    });
+
+    const unlikeButton = screen.getByRole("button", { name: "Unlike profile" });
+    await userEvent.click(unlikeButton);
+
+    expect(screen.getByText("Remove Favorite?")).toBeInTheDocument();
+    expect(mockUnlikeProfile).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole("button", { name: "Remove" }));
+    await waitFor(() => {
+      expect(mockUnlikeProfile).toHaveBeenCalledWith("liked-1");
+    });
+  });
+});
+

--- a/frontend/src/app/(app)/favorites/page.tsx
+++ b/frontend/src/app/(app)/favorites/page.tsx
@@ -6,7 +6,7 @@ import { createClient } from "@/lib/supabase/client";
 import { api, isApiErrorWithStatus, type ProfileLikeResponse, type ProfileResponse } from "@/lib/api";
 import { Aurora } from "@/components/aurora";
 import { ConfirmationDialog } from "@/components/confirmation-dialog";
-import { Heart } from "lucide-react";
+import { Heart, Search } from "lucide-react";
 
 type FavoriteItem = {
   like: ProfileLikeResponse;
@@ -27,6 +27,7 @@ export default function FavoritesPage() {
   const [loading, setLoading] = useState(true);
   const [favorites, setFavorites] = useState<FavoriteItem[]>([]);
   const [confirmUnlikeUserId, setConfirmUnlikeUserId] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
 
   useEffect(() => {
     async function load() {
@@ -121,7 +122,20 @@ export default function FavoritesPage() {
     await runLikeToggle(targetUserId);
   }
 
-  const visibleFavorites = favorites.filter((item) => item.liked);
+  const normalizedQuery = searchQuery.trim().toLowerCase();
+  const visibleFavorites = favorites.filter((item) => {
+    if (!item.liked) return false;
+    if (!normalizedQuery) return true;
+
+    const name = item.profile?.full_name?.toLowerCase() ?? "";
+    const headline = item.profile?.headline?.toLowerCase() ?? "";
+    const eventName = item.like.event_name?.toLowerCase() ?? "";
+    return (
+      name.includes(normalizedQuery) ||
+      headline.includes(normalizedQuery) ||
+      eventName.includes(normalizedQuery)
+    );
+  });
 
   return (
     <div className="relative flex min-h-dvh flex-col overflow-hidden">
@@ -147,6 +161,21 @@ export default function FavoritesPage() {
         >
           Favorites
         </h1>
+        <div
+          className="mt-3 flex items-center gap-2 rounded-2xl px-3 py-2.5"
+          style={{
+            background: "rgba(255,255,255,0.06)",
+            border: "1px solid rgba(255,255,255,0.10)",
+          }}
+        >
+          <Search className="h-4 w-4 text-white/35" />
+          <input
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder="Search favorites"
+            className="w-full bg-transparent text-[14px] text-white placeholder:text-white/30 outline-none"
+          />
+        </div>
       </div>
 
       <div className="relative z-10 flex-1 overflow-y-auto px-6 pb-4">
@@ -156,9 +185,13 @@ export default function FavoritesPage() {
           </div>
         ) : visibleFavorites.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-20 text-center">
-            <p className="text-[15px] text-white/30">No favorites yet</p>
+            <p className="text-[15px] text-white/30">
+              {normalizedQuery ? "No matches found" : "No favorites yet"}
+            </p>
             <p className="mt-2 text-[13px] text-white/15">
-              Like people from recognition to save them here
+              {normalizedQuery
+                ? "Try a different name, headline, or event"
+                : "Like people from recognition to save them here"}
             </p>
           </div>
         ) : (

--- a/frontend/src/app/(app)/favorites/page.tsx
+++ b/frontend/src/app/(app)/favorites/page.tsx
@@ -43,20 +43,10 @@ export default function FavoritesPage() {
       api.setToken(session.access_token);
       try {
         const likes = await api.getMyProfileLikes();
-        const profiles = await Promise.all(
-          likes.map(async (like) => {
-            try {
-              return await api.getProfileById(like.liked_profile_id);
-            } catch {
-              return null;
-            }
-          }),
-        );
-
         setFavorites(
-          likes.map((like, index) => ({
+          likes.map((like) => ({
             like,
-            profile: profiles[index],
+            profile: like.liked_profile,
             liked: true,
             pending: false,
           })),

--- a/frontend/src/app/(app)/favorites/page.tsx
+++ b/frontend/src/app/(app)/favorites/page.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { createClient } from "@/lib/supabase/client";
+import { api, isApiErrorWithStatus, type ProfileLikeResponse, type ProfileResponse } from "@/lib/api";
+import { Aurora } from "@/components/aurora";
+import { ConfirmationDialog } from "@/components/confirmation-dialog";
+import { Heart } from "lucide-react";
+
+type FavoriteItem = {
+  like: ProfileLikeResponse;
+  profile: ProfileResponse | null;
+  liked: boolean;
+  pending: boolean;
+};
+
+function resolvePhotoUrl(photoPath: string | null): string | null {
+  if (!photoPath) return null;
+  const normalizedPhotoPath = photoPath.trim();
+  if (!normalizedPhotoPath) return null;
+  return normalizedPhotoPath;
+}
+
+export default function FavoritesPage() {
+  const router = useRouter();
+  const [loading, setLoading] = useState(true);
+  const [favorites, setFavorites] = useState<FavoriteItem[]>([]);
+  const [confirmUnlikeUserId, setConfirmUnlikeUserId] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      const supabase = createClient();
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+      if (!session) {
+        router.push("/login");
+        return;
+      }
+
+      api.setToken(session.access_token);
+      try {
+        const likes = await api.getMyProfileLikes();
+        const profiles = await Promise.all(
+          likes.map(async (like) => {
+            try {
+              return await api.getProfileById(like.liked_profile_id);
+            } catch {
+              return null;
+            }
+          }),
+        );
+
+        setFavorites(
+          likes.map((like, index) => ({
+            like,
+            profile: profiles[index],
+            liked: true,
+            pending: false,
+          })),
+        );
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    void load();
+  }, [router]);
+
+  async function runLikeToggle(targetUserId: string) {
+    const target = favorites.find((item) => item.like.liked_profile_id === targetUserId);
+    if (!target || target.pending) return;
+
+    setFavorites((prev) => {
+      const next = prev.map((item) => {
+        if (item.like.liked_profile_id !== targetUserId) return item;
+        return { ...item, pending: true, liked: !item.liked };
+      });
+      return next;
+    });
+
+    try {
+      if (target.liked) {
+        await api.unlikeProfile(targetUserId);
+      } else {
+        if (!target.like.event_id) {
+          throw new Error("Cannot re-like without event context.");
+        }
+        await api.likeProfile(targetUserId, target.like.event_id);
+      }
+    } catch (error) {
+      if (!(isApiErrorWithStatus(error, 409) && !target.liked)) {
+        setFavorites((prev) =>
+          prev.map((item) =>
+            item.like.liked_profile_id === targetUserId
+              ? { ...item, liked: target!.liked, pending: false }
+              : item,
+          ),
+        );
+        return;
+      }
+    }
+
+    setFavorites((prev) =>
+      prev.map((item) =>
+        item.like.liked_profile_id === targetUserId ? { ...item, pending: false } : item,
+      ),
+    );
+  }
+
+  async function toggleLike(targetUserId: string) {
+    const target = favorites.find((item) => item.like.liked_profile_id === targetUserId);
+    if (!target || target.pending) return;
+
+    if (target.liked) {
+      setConfirmUnlikeUserId(targetUserId);
+      return;
+    }
+
+    await runLikeToggle(targetUserId);
+  }
+
+  const visibleFavorites = favorites.filter((item) => item.liked);
+
+  return (
+    <div className="relative flex min-h-dvh flex-col overflow-hidden">
+      <div className="absolute inset-0" style={{ opacity: 0.45 }}>
+        <Aurora className="h-full w-full" mode="focused" />
+      </div>
+      <div
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background: "linear-gradient(to bottom, transparent 20%, oklch(0.07 0.015 270) 55%)",
+        }}
+      />
+
+      <div className="relative z-10 px-6 pt-14 pb-5">
+        <h1
+          className="text-white"
+          style={{
+            fontFamily: "var(--font-serif)",
+            fontSize: 28,
+            fontWeight: 400,
+            letterSpacing: "-0.02em",
+          }}
+        >
+          Favorites
+        </h1>
+      </div>
+
+      <div className="relative z-10 flex-1 overflow-y-auto px-6 pb-4">
+        {loading ? (
+          <div className="flex items-center justify-center py-16">
+            <div className="h-6 w-6 animate-spin rounded-full border-2 border-white/10 border-t-white/40" />
+          </div>
+        ) : visibleFavorites.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-20 text-center">
+            <p className="text-[15px] text-white/30">No favorites yet</p>
+            <p className="mt-2 text-[13px] text-white/15">
+              Like people from recognition to save them here
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {visibleFavorites.map((item, index) => (
+              <FavoriteCard
+                key={item.like.liked_profile_id}
+                item={item}
+                index={index}
+                onSelect={() => {
+                  const profilePath = item.like.event_id
+                    ? `/profile/${item.like.liked_profile_id}?event_id=${encodeURIComponent(item.like.event_id)}&source=favorites`
+                    : `/profile/${item.like.liked_profile_id}?source=favorites`;
+                  router.push(profilePath);
+                }}
+                onToggleLike={() => {
+                  void toggleLike(item.like.liked_profile_id);
+                }}
+              />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <ConfirmationDialog
+        open={Boolean(confirmUnlikeUserId)}
+        title="Remove Favorite?"
+        message="This profile will be removed from your favorites."
+        confirmLabel="Remove"
+        onConfirm={() => {
+          const targetUserId = confirmUnlikeUserId;
+          setConfirmUnlikeUserId(null);
+          if (!targetUserId) return;
+          void runLikeToggle(targetUserId);
+        }}
+        onCancel={() => setConfirmUnlikeUserId(null)}
+      />
+    </div>
+  );
+}
+
+function FavoriteCard({
+  item,
+  index,
+  onSelect,
+  onToggleLike,
+}: {
+  item: FavoriteItem;
+  index: number;
+  onSelect: () => void;
+  onToggleLike: () => void;
+}) {
+  const [imgFailed, setImgFailed] = useState(false);
+  const profile = item.profile;
+  const name = profile?.full_name ?? "Unknown person";
+  const initials = name
+    .split(" ")
+    .map((n) => n[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+  const photoUrl = resolvePhotoUrl(profile?.photo_path ?? null);
+
+  return (
+    <div
+      className="rounded-2xl p-4 cursor-pointer active:scale-[0.98] transition-transform"
+      style={{
+        background: "rgba(255,255,255,0.07)",
+        border: "1px solid rgba(255,255,255,0.12)",
+        animation: `fade-in 0.4s cubic-bezier(0.16,1,0.3,1) ${index * 45}ms both`,
+      }}
+      onClick={onSelect}
+    >
+      <div className="flex items-start gap-3">
+        {photoUrl && !imgFailed ? (
+          <img
+            src={photoUrl}
+            alt={name}
+            className="h-12 w-12 shrink-0 rounded-full object-cover mt-0.5"
+            style={{ border: "1px solid rgba(255,255,255,0.10)" }}
+            onError={() => setImgFailed(true)}
+          />
+        ) : (
+          <div
+            className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full text-[15px] font-medium text-white/60 mt-0.5"
+            style={{
+              background: "rgba(255,255,255,0.06)",
+              border: "1px solid rgba(255,255,255,0.10)",
+            }}
+          >
+            {initials}
+          </div>
+        )}
+
+        <div className="min-w-0 flex-1">
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0">
+              <p className="truncate text-[15px] font-semibold text-white">{name}</p>
+              {profile?.headline && (
+                <p className="truncate text-[13px] text-white/45 mt-0.5">{profile.headline}</p>
+              )}
+              <p className="text-[11px] mt-1.5 text-white/35">
+                Met at: {item.like.event_name ?? "Unknown event"}
+              </p>
+            </div>
+
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                onToggleLike();
+              }}
+              disabled={item.pending}
+              className="rounded-full p-1.5 transition-all active:scale-90 disabled:opacity-40"
+              aria-label={item.liked ? "Unlike profile" : "Like profile"}
+              title={item.liked ? "Unlike" : "Like"}
+            >
+              <Heart
+                className={`h-4 w-4 transition-all ${
+                  item.liked ? "fill-red-500 text-red-500 scale-110" : "text-white/40"
+                }`}
+              />
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(app)/profile/[userId]/page.tsx
+++ b/frontend/src/app/(app)/profile/[userId]/page.tsx
@@ -5,6 +5,7 @@ import { useRouter, useParams, useSearchParams } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { api, isApiErrorWithStatus, type ProfileResponse } from "@/lib/api";
 import { Aurora } from "@/components/aurora";
+import { ConfirmationDialog } from "@/components/confirmation-dialog";
 import { ChevronLeft, MapPin, Briefcase, GraduationCap, ExternalLink, Heart } from "lucide-react";
 
 function resolvePhotoUrl(photoPath: string | null): string | null {
@@ -20,11 +21,14 @@ export default function UserProfilePage() {
   const searchParams = useSearchParams();
   const userId = params.userId as string;
   const eventId = searchParams.get("event_id")?.trim() || null;
+  const source = searchParams.get("source")?.trim() || null;
+  const cameFromFavorites = source === "favorites";
   const [profile, setProfile] = useState<ProfileResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [imgFailed, setImgFailed] = useState(false);
   const [liked, setLiked] = useState(false);
   const [likePending, setLikePending] = useState(false);
+  const [confirmUnlikeOpen, setConfirmUnlikeOpen] = useState(false);
 
   useEffect(() => {
     // Show cached data instantly if available
@@ -58,7 +62,7 @@ export default function UserProfilePage() {
     void load();
   }, [userId, router]);
 
-  async function toggleLike() {
+  async function runToggleLike() {
     if (likePending) return;
     if (!liked && !eventId) return;
 
@@ -79,6 +83,14 @@ export default function UserProfilePage() {
     } finally {
       setLikePending(false);
     }
+  }
+
+  async function toggleLike() {
+    if (liked && cameFromFavorites) {
+      setConfirmUnlikeOpen(true);
+      return;
+    }
+    await runToggleLike();
   }
 
   if (loading) {
@@ -271,6 +283,18 @@ export default function UserProfilePage() {
           )}
         </div>
       </div>
+
+      <ConfirmationDialog
+        open={confirmUnlikeOpen}
+        title="Remove Favorite?"
+        message="This profile will be removed from your favorites."
+        confirmLabel="Remove"
+        onConfirm={() => {
+          setConfirmUnlikeOpen(false);
+          void runToggleLike();
+        }}
+        onCancel={() => setConfirmUnlikeOpen(false)}
+      />
     </div>
   );
 }

--- a/frontend/src/app/(app)/profile/[userId]/page.tsx
+++ b/frontend/src/app/(app)/profile/[userId]/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useRouter, useParams } from "next/navigation";
+import { useRouter, useParams, useSearchParams } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
-import { api, type ProfileResponse } from "@/lib/api";
+import { api, isApiErrorWithStatus, type ProfileResponse } from "@/lib/api";
 import { Aurora } from "@/components/aurora";
-import { ChevronLeft, MapPin, Briefcase, GraduationCap, ExternalLink } from "lucide-react";
+import { ChevronLeft, MapPin, Briefcase, GraduationCap, ExternalLink, Heart } from "lucide-react";
 
 function resolvePhotoUrl(photoPath: string | null): string | null {
   if (!photoPath) return null;
@@ -17,20 +17,22 @@ function resolvePhotoUrl(photoPath: string | null): string | null {
 export default function UserProfilePage() {
   const router = useRouter();
   const params = useParams();
+  const searchParams = useSearchParams();
   const userId = params.userId as string;
+  const eventId = searchParams.get("event_id")?.trim() || null;
   const [profile, setProfile] = useState<ProfileResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [imgFailed, setImgFailed] = useState(false);
+  const [liked, setLiked] = useState(false);
+  const [likePending, setLikePending] = useState(false);
 
   useEffect(() => {
     // Show cached data instantly if available
-    let hadCache = false;
     const cached = sessionStorage.getItem(`profile_cache_${userId}`);
     if (cached) {
       try {
         setProfile(JSON.parse(cached));
         setLoading(false);
-        hadCache = true;
       } catch { /* ignore bad cache */ }
     }
 
@@ -40,8 +42,12 @@ export default function UserProfilePage() {
       if (!session) { router.push("/login"); return; }
       api.setToken(session.access_token);
       try {
-        const p = await api.getProfileById(userId);
+        const [p, likes] = await Promise.all([
+          api.getProfileById(userId),
+          api.getMyProfileLikes(),
+        ]);
         setProfile(p);
+        setLiked(likes.some((like) => like.liked_profile_id === userId));
         sessionStorage.setItem(`profile_cache_${userId}`, JSON.stringify(p));
       } catch {
         // If fetch fails and we already have cached data, keep showing it
@@ -49,8 +55,31 @@ export default function UserProfilePage() {
         setLoading(false);
       }
     }
-    load();
+    void load();
   }, [userId, router]);
+
+  async function toggleLike() {
+    if (likePending) return;
+    if (!liked && !eventId) return;
+
+    const wasLiked = liked;
+    setLikePending(true);
+    setLiked(!wasLiked);
+
+    try {
+      if (wasLiked) {
+        await api.unlikeProfile(userId);
+      } else {
+        await api.likeProfile(userId, eventId!);
+      }
+    } catch (error) {
+      if (!(isApiErrorWithStatus(error, 409) && !wasLiked)) {
+        setLiked(wasLiked);
+      }
+    } finally {
+      setLikePending(false);
+    }
+  }
 
   if (loading) {
     return (
@@ -93,15 +122,33 @@ export default function UserProfilePage() {
         }}
       />
 
-      {/* Back button */}
+      {/* Header actions */}
       <div className="relative z-10 px-4 pt-14">
-        <button
-          onClick={() => router.back()}
-          className="flex items-center gap-1 text-white/40 active:text-white/70 transition-colors"
-        >
-          <ChevronLeft className="h-5 w-5" />
-          <span className="text-[14px]">Back</span>
-        </button>
+        <div className="flex items-center justify-between">
+          <button
+            onClick={() => router.back()}
+            className="flex items-center gap-1 text-white/40 active:text-white/70 transition-colors"
+          >
+            <ChevronLeft className="h-5 w-5" />
+            <span className="text-[14px]">Back</span>
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              void toggleLike();
+            }}
+            disabled={likePending || (!liked && !eventId)}
+            className="rounded-full p-2 transition-all active:scale-90 disabled:opacity-40"
+            title={!liked && !eventId ? "Event context required to like" : "Toggle like"}
+            aria-label={liked ? "Unlike profile" : "Like profile"}
+          >
+            <Heart
+              className={`h-5 w-5 transition-all ${
+                liked ? "fill-red-500 text-red-500 scale-110" : "text-white/45"
+              }`}
+            />
+          </button>
+        </div>
       </div>
 
       {/* Scrollable content */}

--- a/frontend/src/app/(app)/recognition/__tests__/recognition-page.test.tsx
+++ b/frontend/src/app/(app)/recognition/__tests__/recognition-page.test.tsx
@@ -15,12 +15,14 @@ import {
 
 const mockGetMyEventConsent = vi.fn();
 const mockGetCompatibility = vi.fn();
+const mockGetMyProfileLikes = vi.fn();
 
 vi.mock("@/lib/api", () => ({
   api: {
     setToken: vi.fn(),
     getMyEventConsent: (...args: unknown[]) => mockGetMyEventConsent(...args),
     getCompatibility: (...args: unknown[]) => mockGetCompatibility(...args),
+    getMyProfileLikes: (...args: unknown[]) => mockGetMyProfileLikes(...args),
   },
 }));
 
@@ -84,6 +86,7 @@ describe("RecognitionPage", () => {
     resetSupabaseMocks();
     mockGetMyEventConsent.mockClear();
     mockGetCompatibility.mockClear();
+    mockGetMyProfileLikes.mockClear().mockResolvedValue([]);
     mockSocketConnect.mockClear();
     mockSocketDisconnect.mockClear();
     mockSocketSend.mockClear();

--- a/frontend/src/app/(app)/recognition/page.tsx
+++ b/frontend/src/app/(app)/recognition/page.tsx
@@ -5,13 +5,14 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import {
   api,
+  isApiErrorWithStatus,
   type ConsentResponse,
   type ProfileResponse,
   type CompatibilityResponse,
 } from "@/lib/api";
 import { getCachedEventConsent, setCachedEventConsent } from "@/lib/consent-cache";
 import { Aurora } from "@/components/aurora";
-import { Camera, LogOut, ScanFace, Square } from "lucide-react";
+import { Camera, Heart, LogOut, ScanFace, Square } from "lucide-react";
 import { SocketClient, type SocketMessage, type ProfileCard } from "@/lib/socket";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -75,6 +76,8 @@ export default function RecognitionPage() {
   const [captureLoading, setCaptureLoading] = useState(false);
   const [cameraMode, setCameraMode] = useState(false);
   const [consentWarning, setConsentWarning] = useState<string | null>(null);
+  const [likedUserIds, setLikedUserIds] = useState<Set<string>>(new Set());
+  const [likePendingUserIds, setLikePendingUserIds] = useState<Set<string>>(new Set());
   const socketRef = useRef<SocketClient | null>(null);
   const mountIdRef = useRef(`dashboard-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
   const videoRef = useRef<HTMLVideoElement | null>(null);
@@ -125,6 +128,12 @@ export default function RecognitionPage() {
 
       accessTokenRef.current = session.access_token;
       api.setToken(session.access_token);
+      try {
+        const likes = await api.getMyProfileLikes();
+        setLikedUserIds(new Set(likes.map((like) => like.liked_profile_id)));
+      } catch (error) {
+        console.error("[Recognition] Failed to load likes:", error);
+      }
       socket.connect(session.access_token);
       setLoading(false);
     }
@@ -362,6 +371,49 @@ export default function RecognitionPage() {
     router.refresh();
   }
 
+  async function toggleLike(userId: string) {
+    if (likePendingUserIds.has(userId)) return;
+    const currentlyLiked = likedUserIds.has(userId);
+    if (!currentlyLiked && !selectedEventId) return;
+
+    setLikePendingUserIds((prev) => {
+      const next = new Set(prev);
+      next.add(userId);
+      return next;
+    });
+
+    setLikedUserIds((prev) => {
+      const next = new Set(prev);
+      if (currentlyLiked) next.delete(userId);
+      else next.add(userId);
+      return next;
+    });
+
+    try {
+      if (currentlyLiked) {
+        await api.unlikeProfile(userId);
+      } else {
+        await api.likeProfile(userId, selectedEventId!);
+      }
+    } catch (error) {
+      // 409 means the like already exists; keep liked state.
+      if (!(isApiErrorWithStatus(error, 409) && !currentlyLiked)) {
+        setLikedUserIds((prev) => {
+          const next = new Set(prev);
+          if (currentlyLiked) next.add(userId);
+          else next.delete(userId);
+          return next;
+        });
+      }
+    } finally {
+      setLikePendingUserIds((prev) => {
+        const next = new Set(prev);
+        next.delete(userId);
+        return next;
+      });
+    }
+  }
+
   return (
     <div className="relative flex min-h-dvh flex-col overflow-hidden">
       {/* Hidden camera elements for phone camera mode */}
@@ -494,7 +546,18 @@ export default function RecognitionPage() {
                   if (r.profile) {
                     sessionStorage.setItem(`profile_cache_${userId}`, JSON.stringify(r.profile));
                   }
-                  router.push(`/profile/${userId}`);
+                  const profilePath = selectedEventId
+                    ? `/profile/${userId}?event_id=${encodeURIComponent(selectedEventId)}`
+                    : `/profile/${userId}`;
+                  router.push(profilePath);
+                }}
+                liked={Boolean(result.matched_user_id && likedUserIds.has(result.matched_user_id))}
+                likePending={Boolean(
+                  result.matched_user_id && likePendingUserIds.has(result.matched_user_id),
+                )}
+                canLike={Boolean(result.matched_user_id && selectedEventId)}
+                onToggleLike={(targetUserId) => {
+                  void toggleLike(targetUserId);
                 }}
               />
             ))}
@@ -545,10 +608,18 @@ function RecognitionCard({
   result,
   index,
   onSelect,
+  liked,
+  likePending,
+  canLike,
+  onToggleLike,
 }: {
   result: RecognitionResult;
   index: number;
   onSelect: (result: RecognitionResult) => void;
+  liked: boolean;
+  likePending: boolean;
+  canLike: boolean;
+  onToggleLike: (userId: string) => void;
 }) {
   const [imgFailed, setImgFailed] = useState(false);
   const profile = result.profile;
@@ -659,7 +730,28 @@ const firstStarter = compat?.conversation_starters?.[0];
                 </p>
               )}
             </div>
-            <p className="shrink-0 text-[11px] text-white/22 pt-0.5">{formatTime(result.created_at)}</p>
+            <div className="shrink-0 flex items-center gap-2 pt-0.5">
+              {result.matched_user_id ? (
+                <button
+                  type="button"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onToggleLike(result.matched_user_id!);
+                  }}
+                  disabled={likePending || (!liked && !canLike)}
+                  className="group rounded-full p-1.5 transition-all active:scale-90 disabled:opacity-40"
+                  title={!liked && !canLike ? "Event context required to like" : "Toggle like"}
+                  aria-label={liked ? "Unlike profile" : "Like profile"}
+                >
+                  <Heart
+                    className={`h-4 w-4 transition-all ${
+                      liked ? "fill-red-500 text-red-500 scale-110" : "text-white/40 group-hover:text-white/60"
+                    }`}
+                  />
+                </button>
+              ) : null}
+              <p className="text-[11px] text-white/22">{formatTime(result.created_at)}</p>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/__tests__/bottom-tab-bar.test.tsx
+++ b/frontend/src/components/__tests__/bottom-tab-bar.test.tsx
@@ -16,6 +16,7 @@ describe("BottomTabBar", () => {
   it("renders all tab labels", () => {
     render(<BottomTabBar />);
     expect(screen.getByText("Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("Favorites")).toBeInTheDocument();
     expect(screen.getByText("Profile")).toBeInTheDocument();
   });
 
@@ -37,6 +38,14 @@ describe("BottomTabBar", () => {
     expect(profileBtn.style.color).toContain("0.95");
   });
 
+  it("highlights Favorites tab when on /favorites path", () => {
+    mockPathname.mockReturnValue("/favorites");
+    const { container } = render(<BottomTabBar />);
+    const buttons = container.querySelectorAll("button");
+    const favoritesBtn = buttons[1];
+    expect(favoritesBtn.style.color).toContain("0.95");
+  });
+
   it("highlights tab for nested paths", () => {
     mockPathname.mockReturnValue("/dashboard/some-sub-page");
     const { container } = render(<BottomTabBar />);
@@ -49,6 +58,12 @@ describe("BottomTabBar", () => {
     render(<BottomTabBar />);
     await userEvent.click(screen.getByText("Profile"));
     expect(mockPush).toHaveBeenCalledWith("/profile");
+  });
+
+  it("navigates to /favorites when Favorites tab is clicked", async () => {
+    render(<BottomTabBar />);
+    await userEvent.click(screen.getByText("Favorites"));
+    expect(mockPush).toHaveBeenCalledWith("/favorites");
   });
 
   it("navigates to /dashboard when Dashboard tab is clicked", async () => {

--- a/frontend/src/components/bottom-tab-bar.tsx
+++ b/frontend/src/components/bottom-tab-bar.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { usePathname, useRouter } from "next/navigation";
-import { CalendarDays, User } from "lucide-react";
+import { CalendarDays, Heart, User } from "lucide-react";
 
 const TABS = [
   { label: "Dashboard", href: "/dashboard", Icon: CalendarDays },
+  { label: "Favorites", href: "/favorites", Icon: Heart },
   { label: "Profile", href: "/profile", Icon: User },
 ];
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -404,6 +404,7 @@ export interface ProfileLikeResponse {
   liked_profile_id: string;
   event_id: string | null;
   event_name: string | null;
+  liked_profile: ProfileResponse | null;
   created_at: string;
 }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -125,6 +125,23 @@ class ApiClient {
     return this.request<ProfileDirectoryResponse>(`/api/v1/profiles/directory/${eventId}`);
   }
 
+  async getMyProfileLikes() {
+    return this.request<ProfileLikeResponse[]>("/api/v1/profiles/me/likes");
+  }
+
+  async likeProfile(userId: string, eventId: string) {
+    return this.request<ProfileLikeResponse>(`/api/v1/profiles/${userId}/like`, {
+      method: "POST",
+      body: JSON.stringify({ event_id: eventId }),
+    });
+  }
+
+  async unlikeProfile(userId: string) {
+    return this.request<void>(`/api/v1/profiles/${userId}/like`, {
+      method: "DELETE",
+    });
+  }
+
   async onboardFromLinkedIn(linkedinUrl: string) {
     return this.request<LinkedInOnboardingResponse>(
       "/api/v1/profiles/onboard-from-linkedin-url",
@@ -331,6 +348,13 @@ export interface ProfileDirectoryResponse {
   entries: ProfileDirectoryEntry[];
   total_count: number;
   hidden_count: number;
+}
+
+export interface ProfileLikeResponse {
+  user_id: string;
+  liked_profile_id: string;
+  event_id: string | null;
+  created_at: string;
 }
 
 export interface ConsentResponse {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -354,6 +354,7 @@ export interface ProfileLikeResponse {
   user_id: string;
   liked_profile_id: string;
   event_id: string | null;
+  event_name: string | null;
   created_at: string;
 }
 


### PR DESCRIPTION
This PR adds a full Favorites workflow for profile likes.

- Added persistent `profile_likes` storage (with event context) via migration + RLS.
- Added profile-like APIs:
  - `GET /profiles/me/likes` (now includes `event_name`)
  - `POST /profiles/{user_id}/like`
  - `DELETE /profiles/{user_id}/like`
- Added a new `Favorites` tab/page (between Dashboard and Profile) to view/search liked profiles and event met-at info.
- Added like/unlike heart interactions across recognition cards, profile detail, and favorites.
- Added confirmation dialog for unlike in Favorites flows (Favorites page and profile page when opened from Favorites).

Resolves #201 