### PR TITLE
Fix/event join

### DIFF
--- a/backend/app/api/memberships.py
+++ b/backend/app/api/memberships.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Annotated
 from uuid import UUID
 
@@ -73,19 +73,11 @@ async def join_event(
             detail="Event not found.",
         )
 
-    event_start = event.starts_at
-    if event_start is None:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Event start time is unexpectedly missing.",
-        )
-
-    join_cutoff = event_start - timedelta(minutes=20)
     now = datetime.now(timezone.utc)
-    if now > join_cutoff:
+    if event.ends_at and now >= event.ends_at:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="You can only join an event at least 20 minutes before it starts.",
+            detail="You can no longer join an event after it has ended.",
         )
 
     # Create membership

--- a/frontend/src/app/(app)/dashboard/discover-events-sheet-content.tsx
+++ b/frontend/src/app/(app)/dashboard/discover-events-sheet-content.tsx
@@ -5,9 +5,6 @@ import { CalendarDays, Loader2, MapPin, Search, UserPlus } from "lucide-react";
 
 export interface DiscoverEventItem {
   event: EventResponse;
-  canStillJoin: boolean;
-  registrationClosesMessage: string;
-  isClosingSoon: boolean;
 }
 
 interface DiscoverEventsSheetContentProps {
@@ -69,7 +66,7 @@ export function DiscoverEventsSheetContent({
           </div>
         ) : (
           <div className="space-y-3">
-            {events.map(({ event, canStillJoin, registrationClosesMessage, isClosingSoon }) => {
+            {events.map(({ event }) => {
 
               return (
                 <article
@@ -101,41 +98,22 @@ export function DiscoverEventsSheetContent({
                   </div>
 
                   <div className="mt-3">
-                    <p
-                      className="mb-2 text-[12px]"
-                      style={{ color: isClosingSoon ? "oklch(0.72 0.17 20)" : "rgba(255,255,255,0.45)" }}
+                    <button
+                      onClick={() => onJoinEvent(event)}
+                      disabled={joiningEventId === event.event_id}
+                      className="inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-[11px] font-medium uppercase tracking-[0.1em] text-white/80 transition-transform active:scale-95 disabled:opacity-55"
+                      style={{
+                        background: "oklch(1 0 0 / 5%)",
+                        border: "1px solid oklch(1 0 0 / 11%)",
+                      }}
                     >
-                      {registrationClosesMessage}
-                    </p>
-                    {canStillJoin ? (
-                      <button
-                        onClick={() => onJoinEvent(event)}
-                        disabled={joiningEventId === event.event_id}
-                        className="inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-[11px] font-medium uppercase tracking-[0.1em] text-white/80 transition-transform active:scale-95 disabled:opacity-55"
-                        style={{
-                          background: "oklch(1 0 0 / 5%)",
-                          border: "1px solid oklch(1 0 0 / 11%)",
-                        }}
-                      >
-                        {joiningEventId === event.event_id ? (
-                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                        ) : (
-                          <UserPlus className="h-3.5 w-3.5" />
-                        )}
-                        {joiningEventId === event.event_id ? "Joining" : "Join Event"}
-                      </button>
-                    ) : (
-                      <span
-                        className="inline-flex items-center rounded-full px-3 py-1.5 text-[11px] font-medium uppercase tracking-[0.08em]"
-                        style={{
-                          background: "oklch(0.25 0.07 20 / 45%)",
-                          border: "1px solid oklch(0.58 0.12 20 / 35%)",
-                          color: "oklch(0.86 0.05 25)",
-                        }}
-                      >
-                        You can no longer RSVP for this event
-                      </span>
-                    )}
+                      {joiningEventId === event.event_id ? (
+                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <UserPlus className="h-3.5 w-3.5" />
+                      )}
+                      {joiningEventId === event.event_id ? "Joining" : "Join Event"}
+                    </button>
                   </div>
                 </article>
               );

--- a/frontend/src/app/(app)/dashboard/page.tsx
+++ b/frontend/src/app/(app)/dashboard/page.tsx
@@ -68,6 +68,7 @@ export default function DashboardPage() {
   const [consentsLoading, setConsentsLoading] = useState(false);
   const [consentsSaving, setConsentsSaving] = useState(false);
   const [editingConsent, setEditingConsent] = useState<ConsentResponse | null>(null);
+  const [joinedEventPrompt, setJoinedEventPrompt] = useState<EventResponse | null>(null);
   const openMenuContainerRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -179,17 +180,7 @@ export default function DashboardPage() {
         const haystack = [event.name, event.location ?? ""].join(" ").toLowerCase();
         return haystack.includes(query);
       })
-      .map((event) => {
-        const startsAt = Date.parse(event.starts_at ?? "");
-        const { message: registrationClosesMessage, isClosingSoon } =
-          formatRegistrationCloseMessage(startsAt, now);
-        return {
-          event,
-          canStillJoin: Number.isFinite(startsAt) && startsAt - now >= 20 * 60 * 1000,
-          registrationClosesMessage,
-          isClosingSoon,
-        };
-      });
+      .map((event) => ({ event }));
   }, [discoverEvents, discoverSearchText, myEvents]);
 
   async function handleSignOut() {
@@ -309,6 +300,7 @@ export default function DashboardPage() {
         }
         return [...previous, event];
       });
+      setJoinedEventPrompt(event);
     } catch (error) {
       console.error("Failed to join event:", error);
     } finally {
@@ -698,6 +690,25 @@ export default function DashboardPage() {
       </ModalBottomSheet>
 
       <ConfirmationDialog
+        open={Boolean(joinedEventPrompt)}
+        title="Joined Event"
+        message={
+          joinedEventPrompt
+            ? `You successfully joined ${joinedEventPrompt.name}. Update your event consents so you can recognize others and be recognized.`
+            : "You successfully joined this event. Update your event consents so you can recognize others and be recognized."
+        }
+        confirmLabel="Update Consents"
+        cancelLabel="Not Now"
+        onConfirm={() => {
+          if (!joinedEventPrompt) return;
+          const joinedEvent = joinedEventPrompt;
+          setJoinedEventPrompt(null);
+          void handleEditConsents(joinedEvent);
+        }}
+        onCancel={() => setJoinedEventPrompt(null)}
+      />
+
+      <ConfirmationDialog
         open={Boolean(confirmLeaveEvent)}
         title="Leave Event?"
         message={
@@ -732,34 +743,4 @@ function formatEventDate(value: string): string {
     hour: "numeric",
     minute: "2-digit",
   }).format(date);
-}
-
-function formatRegistrationCloseMessage(
-  startsAtMs: number,
-  nowMs: number,
-): { message: string; isClosingSoon: boolean } {
-  if (!Number.isFinite(startsAtMs)) {
-    return { message: "Registration close time unavailable", isClosingSoon: false };
-  }
-
-  const closesAtMs = startsAtMs - 20 * 60 * 1000;
-  const remainingMs = closesAtMs - nowMs;
-
-  if (remainingMs > 0 && remainingMs <= 5 * 60 * 1000) {
-    const remainingMinutes = Math.max(1, Math.ceil(remainingMs / 60000));
-    return {
-      message: `Registration closes in ${remainingMinutes} minute${remainingMinutes === 1 ? "" : "s"}`,
-      isClosingSoon: true,
-    };
-  }
-
-  const closesAt = new Date(closesAtMs);
-  return {
-    message: `Registration closes at ${new Intl.DateTimeFormat("en-US", {
-      hour: "numeric",
-      minute: "2-digit",
-      hour12: true,
-    }).format(closesAt)}`,
-    isClosingSoon: false,
-  };
 }


### PR DESCRIPTION
Join event API now allows users join events as long as `now() < event.starts_at`
Frontend was updated to reflect the change above and now prompts users to update the consents to enable recognition for themselves.

Fixes #268 