### PR TITLE
fix: validate LinkedIn username format before onboarding import

### DIFF
--- a/frontend/src/app/(app)/onboarding/page.tsx
+++ b/frontend/src/app/(app)/onboarding/page.tsx
@@ -177,6 +177,15 @@ export default function OnboardingPage() {
 
   async function handleSubmit() {
     setError(null);
+
+    if (!isResume) {
+      const username = linkedinUrl.trim().replace(/^.*linkedin\.com\/in\//i, "").replace(/\/+$/, "");
+      if (!/^[a-zA-Z0-9-]{3,100}$/.test(username)) {
+        setError("Please enter a valid LinkedIn username (letters, numbers, and hyphens only).");
+        return;
+      }
+    }
+
     setLoading(true);
     try {
       const supabase = createClient();


### PR DESCRIPTION
During onboarding, if a user entered an invalid LinkedIn username (spaces, special characters, or too short), the app would submit it to the API and move forward with bad data. The user couldn't go back to fix it since the profile was already created. Added a regex validation check that runs before the API call. If the username doesn't match the expected format (letters, numbers, and hyphens, at least 3 characters), the user sees an error message and stays on the same screen to correct it.

Resolves #272 