### PR TITLE
feat: add editable LinkedIn URL field to profile page

### DIFF
--- a/frontend/src/app/(app)/profile/page.tsx
+++ b/frontend/src/app/(app)/profile/page.tsx
@@ -15,6 +15,7 @@ import {
   GraduationCap,
   Pencil,
   LogOut,
+  Link2,
 } from "lucide-react";
 
 export default function ProfilePage() {
@@ -282,6 +283,32 @@ export default function ProfilePage() {
               onSave={saveEdit}
               onDraftChange={setDraftValue}
               placeholder="Add a location"
+              displayClassName="text-[14px] text-white/60"
+              inputClassName="w-full bg-transparent text-[14px] text-white/80 outline-none"
+            />
+          </SectionCard>
+
+          {/* LinkedIn */}
+          <SectionCard
+            label="LinkedIn"
+            icon={<Link2 className="h-3.5 w-3.5" />}
+            onEdit={
+              editField !== "linkedin_url"
+                ? () => startEdit("linkedin_url", profile.linkedin_url ?? "")
+                : undefined
+            }
+          >
+            <FieldEditor
+              field="linkedin_url"
+              value={profile.linkedin_url ?? ""}
+              editField={editField}
+              draftValue={draftValue}
+              saving={saving}
+              onStart={startEdit}
+              onCancel={cancelEdit}
+              onSave={saveEdit}
+              onDraftChange={setDraftValue}
+              placeholder="Add a LinkedIn URL"
               displayClassName="text-[14px] text-white/60"
               inputClassName="w-full bg-transparent text-[14px] text-white/80 outline-none"
             />


### PR DESCRIPTION
Previously, there was no way to view or edit the LinkedIn URL after completing onboarding. If a user entered it wrong during signup, they were stuck with bad data and had to create a new account. Added a LinkedIn URL field to the profile page using the existing FieldEditor and SectionCard pattern, so users can tap to edit and save a corrected URL at any time.

Resolves #273 