### PR TITLE
feat: add password reset flow and server-side sign-out

### DIFF
--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -30,6 +30,7 @@ from app.auth.schemas import (
     UserInfo,
 )
 from app.config import get_settings
+from app.db.supabase import get_admin_client, get_supabase_client
 from supabase import create_client
 
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -335,11 +336,14 @@ async def signout(
     current_user: Annotated[CurrentUser, Depends(get_current_user)],
 ) -> MessageResponse:
     """
-    Sign out the current user by revoking the Supabase session server-side.
-    The client should also clear all local auth state after calling this.
+    Revoke the user's session server-side via Supabase Admin API.
+
+    This complements the client-side supabase.auth.signOut() which only clears
+    local state. Server-side revocation invalidates the JWT at Supabase so it
+    cannot be reused if intercepted (e.g. stolen token, shared device).
+    The client should still clear local auth state after calling this.
     """
-    settings = get_settings()
-    admin_client = create_client(settings.supabase_url, settings.supabase_service_role_key)
+    admin_client = get_admin_client()
 
     try:
         admin_client.auth.admin.sign_out(current_user.access_token)
@@ -360,8 +364,7 @@ async def request_password_reset(data: PasswordResetRequest) -> MessageResponse:
     Send a password reset email to the user.
     Always returns success to prevent email enumeration.
     """
-    settings = get_settings()
-    supabase = create_client(settings.supabase_url, settings.supabase_anon_key)
+    supabase = get_supabase_client()
 
     try:
         opts: Options | None = None

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -10,14 +10,19 @@ from typing import Annotated
 from urllib.parse import urlencode
 from uuid import UUID
 
+import httpx
 from fastapi import APIRouter, Body, Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from gotrue.types import Options
 
 from app.auth.dependencies import CurrentUser, get_current_user, verify_jwt
 from app.auth.schemas import (
     AuthResponse,
+    MessageResponse,
     OAuthCallbackRequest,
     OAuthUrlResponse,
+    PasswordResetConfirmRequest,
+    PasswordResetRequest,
     SignInRequest,
     SignUpRequest,
     TokenVerifyRequest,
@@ -25,6 +30,7 @@ from app.auth.schemas import (
     UserInfo,
 )
 from app.config import get_settings
+from supabase import create_client
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 security = HTTPBearer(auto_error=False)
@@ -87,8 +93,6 @@ async def signup(data: SignUpRequest) -> AuthResponse:
     Create a new user account with email and password.
     Returns access and refresh tokens on success.
     """
-    from supabase import create_client
-
     settings = get_settings()
     supabase = create_client(settings.supabase_url, settings.supabase_anon_key)
 
@@ -142,8 +146,6 @@ async def signin(data: SignInRequest) -> AuthResponse:
     Sign in with email and password.
     Returns access and refresh tokens on success.
     """
-    from supabase import create_client
-
     settings = get_settings()
     supabase = create_client(settings.supabase_url, settings.supabase_anon_key)
 
@@ -269,8 +271,6 @@ async def oauth_callback(data: OAuthCallbackRequest) -> AuthResponse:
 
     Automatically creates a user profile on first sign-in using OAuth metadata.
     """
-    import httpx
-
     settings = get_settings()
 
     try:
@@ -322,6 +322,101 @@ async def oauth_callback(data: OAuthCallbackRequest) -> AuthResponse:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=f"OAuth callback failed: {str(e)}",
+        )
+
+
+# =============================================================================
+# Sign-Out
+# =============================================================================
+
+
+@router.post("/signout", response_model=MessageResponse)
+async def signout(
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+) -> MessageResponse:
+    """
+    Sign out the current user by revoking the Supabase session server-side.
+    The client should also clear all local auth state after calling this.
+    """
+    settings = get_settings()
+    admin_client = create_client(settings.supabase_url, settings.supabase_service_role_key)
+
+    try:
+        admin_client.auth.admin.sign_out(current_user.access_token)
+    except Exception:
+        pass
+
+    return MessageResponse(message="Signed out successfully")
+
+
+# =============================================================================
+# Password Reset
+# =============================================================================
+
+
+@router.post("/reset-password", response_model=MessageResponse)
+async def request_password_reset(data: PasswordResetRequest) -> MessageResponse:
+    """
+    Send a password reset email to the user.
+    Always returns success to prevent email enumeration.
+    """
+    settings = get_settings()
+    supabase = create_client(settings.supabase_url, settings.supabase_anon_key)
+
+    try:
+        opts: Options | None = None
+        if data.redirect_to:
+            opts = Options(redirect_to=data.redirect_to)
+
+        supabase.auth.reset_password_email(data.email, options=opts)
+    except Exception:
+        pass
+
+    return MessageResponse(
+        message="If an account with that email exists, a reset link has been sent."
+    )
+
+
+@router.post("/reset-password/confirm", response_model=MessageResponse)
+async def confirm_password_reset(
+    data: PasswordResetConfirmRequest,
+) -> MessageResponse:
+    """
+    Set a new password using the access token from the password reset email link.
+    The frontend extracts the access_token from the URL fragment after the user
+    clicks the reset link, then sends it here along with the new password.
+    """
+    settings = get_settings()
+
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.put(
+                f"{settings.supabase_url}/auth/v1/user",
+                json={"password": data.new_password},
+                headers={
+                    "apikey": settings.supabase_anon_key,
+                    "Authorization": f"Bearer {data.access_token}",
+                    "Content-Type": "application/json",
+                },
+            )
+
+        if response.status_code != 200:
+            error_detail = response.json().get(
+                "message", response.json().get("msg", "Password update failed")
+            )
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=error_detail,
+            )
+
+        return MessageResponse(message="Password updated successfully")
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Password reset failed: {str(e)}",
         )
 
 

--- a/backend/app/auth/router.py
+++ b/backend/app/auth/router.py
@@ -13,7 +13,7 @@ from uuid import UUID
 import httpx
 from fastapi import APIRouter, Body, Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from gotrue.types import Options
+from supabase_auth.types import Options
 
 from app.auth.dependencies import CurrentUser, get_current_user, verify_jwt
 from app.auth.schemas import (

--- a/backend/app/auth/schemas.py
+++ b/backend/app/auth/schemas.py
@@ -67,3 +67,23 @@ class OAuthCallbackRequest(BaseModel):
 
     code: str
     code_verifier: str  # The code_verifier from the initial OAuth URL response
+
+
+class PasswordResetRequest(BaseModel):
+    """Request body for POST /auth/reset-password — triggers reset email."""
+
+    email: EmailStr
+    redirect_to: str | None = None
+
+
+class PasswordResetConfirmRequest(BaseModel):
+    """Request body for POST /auth/reset-password/confirm — sets a new password."""
+
+    access_token: str
+    new_password: str
+
+
+class MessageResponse(BaseModel):
+    """Generic message response."""
+
+    message: str

--- a/backend/tests/test_auth_password_reset.py
+++ b/backend/tests/test_auth_password_reset.py
@@ -40,10 +40,10 @@ class TestSignOut:
         response = client.post("/api/v1/auth/signout")
         assert response.status_code == 401
 
-    @patch("app.auth.router.create_client")
-    def test_signout_success(self, mock_create_client, authed_client):
+    @patch("app.auth.router.get_admin_client")
+    def test_signout_success(self, mock_get_admin, authed_client):
         mock_supabase = MagicMock()
-        mock_create_client.return_value = mock_supabase
+        mock_get_admin.return_value = mock_supabase
 
         response = authed_client.post("/api/v1/auth/signout")
 
@@ -52,12 +52,12 @@ class TestSignOut:
         assert data["message"] == "Signed out successfully"
         mock_supabase.auth.admin.sign_out.assert_called_once_with("fake-token")
 
-    @patch("app.auth.router.create_client")
-    def test_signout_succeeds_even_if_supabase_fails(self, mock_create_client, authed_client):
+    @patch("app.auth.router.get_admin_client")
+    def test_signout_succeeds_even_if_supabase_fails(self, mock_get_admin, authed_client):
         """Sign-out should not fail even if Supabase throws an error."""
         mock_supabase = MagicMock()
         mock_supabase.auth.admin.sign_out.side_effect = Exception("Supabase down")
-        mock_create_client.return_value = mock_supabase
+        mock_get_admin.return_value = mock_supabase
 
         response = authed_client.post("/api/v1/auth/signout")
 
@@ -71,10 +71,10 @@ class TestSignOut:
 class TestPasswordResetRequest:
     """Tests for POST /api/v1/auth/reset-password."""
 
-    @patch("app.auth.router.create_client")
-    def test_reset_password_sends_email(self, mock_create_client, client):
+    @patch("app.auth.router.get_supabase_client")
+    def test_reset_password_sends_email(self, mock_get_client, client):
         mock_supabase = MagicMock()
-        mock_create_client.return_value = mock_supabase
+        mock_get_client.return_value = mock_supabase
 
         response = client.post(
             "/api/v1/auth/reset-password",
@@ -86,10 +86,10 @@ class TestPasswordResetRequest:
         assert "reset link" in data["message"].lower()
         mock_supabase.auth.reset_password_email.assert_called_once()
 
-    @patch("app.auth.router.create_client")
-    def test_reset_password_with_redirect(self, mock_create_client, client):
+    @patch("app.auth.router.get_supabase_client")
+    def test_reset_password_with_redirect(self, mock_get_client, client):
         mock_supabase = MagicMock()
-        mock_create_client.return_value = mock_supabase
+        mock_get_client.return_value = mock_supabase
 
         response = client.post(
             "/api/v1/auth/reset-password",
@@ -103,12 +103,12 @@ class TestPasswordResetRequest:
         call_args = mock_supabase.auth.reset_password_email.call_args
         assert call_args[1]["options"]["redirect_to"] == "https://example.com/reset"
 
-    @patch("app.auth.router.create_client")
-    def test_reset_password_always_succeeds_for_unknown_email(self, mock_create_client, client):
+    @patch("app.auth.router.get_supabase_client")
+    def test_reset_password_always_succeeds_for_unknown_email(self, mock_get_client, client):
         """Prevents email enumeration — always returns success."""
         mock_supabase = MagicMock()
         mock_supabase.auth.reset_password_email.side_effect = Exception("User not found")
-        mock_create_client.return_value = mock_supabase
+        mock_get_client.return_value = mock_supabase
 
         response = client.post(
             "/api/v1/auth/reset-password",

--- a/backend/tests/test_auth_password_reset.py
+++ b/backend/tests/test_auth_password_reset.py
@@ -1,0 +1,207 @@
+"""Tests for password reset and sign-out endpoints."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.auth.dependencies import CurrentUser, get_current_user
+from app.main import app
+
+FAKE_USER = CurrentUser(
+    id=UUID("00000000-0000-0000-0000-000000000001"),
+    email="test@example.com",
+    access_token="fake-token",
+)
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def authed_client():
+    """Client with auth dependency overridden."""
+    app.dependency_overrides[get_current_user] = lambda: FAKE_USER
+    c = TestClient(app)
+    yield c
+    app.dependency_overrides.pop(get_current_user, None)
+
+
+# ─── Sign-Out ──────────────────────────────────────────────────────────────────
+
+
+class TestSignOut:
+    """Tests for POST /api/v1/auth/signout."""
+
+    def test_signout_requires_authentication(self, client):
+        response = client.post("/api/v1/auth/signout")
+        assert response.status_code == 401
+
+    @patch("app.auth.router.create_client")
+    def test_signout_success(self, mock_create_client, authed_client):
+        mock_supabase = MagicMock()
+        mock_create_client.return_value = mock_supabase
+
+        response = authed_client.post("/api/v1/auth/signout")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["message"] == "Signed out successfully"
+        mock_supabase.auth.admin.sign_out.assert_called_once_with("fake-token")
+
+    @patch("app.auth.router.create_client")
+    def test_signout_succeeds_even_if_supabase_fails(self, mock_create_client, authed_client):
+        """Sign-out should not fail even if Supabase throws an error."""
+        mock_supabase = MagicMock()
+        mock_supabase.auth.admin.sign_out.side_effect = Exception("Supabase down")
+        mock_create_client.return_value = mock_supabase
+
+        response = authed_client.post("/api/v1/auth/signout")
+
+        assert response.status_code == 200
+        assert response.json()["message"] == "Signed out successfully"
+
+
+# ─── Password Reset Request ───────────────────────────────────────────────────
+
+
+class TestPasswordResetRequest:
+    """Tests for POST /api/v1/auth/reset-password."""
+
+    @patch("app.auth.router.create_client")
+    def test_reset_password_sends_email(self, mock_create_client, client):
+        mock_supabase = MagicMock()
+        mock_create_client.return_value = mock_supabase
+
+        response = client.post(
+            "/api/v1/auth/reset-password",
+            json={"email": "test@example.com"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "reset link" in data["message"].lower()
+        mock_supabase.auth.reset_password_email.assert_called_once()
+
+    @patch("app.auth.router.create_client")
+    def test_reset_password_with_redirect(self, mock_create_client, client):
+        mock_supabase = MagicMock()
+        mock_create_client.return_value = mock_supabase
+
+        response = client.post(
+            "/api/v1/auth/reset-password",
+            json={
+                "email": "test@example.com",
+                "redirect_to": "https://example.com/reset",
+            },
+        )
+
+        assert response.status_code == 200
+        call_args = mock_supabase.auth.reset_password_email.call_args
+        assert call_args[1]["options"]["redirect_to"] == "https://example.com/reset"
+
+    @patch("app.auth.router.create_client")
+    def test_reset_password_always_succeeds_for_unknown_email(self, mock_create_client, client):
+        """Prevents email enumeration — always returns success."""
+        mock_supabase = MagicMock()
+        mock_supabase.auth.reset_password_email.side_effect = Exception("User not found")
+        mock_create_client.return_value = mock_supabase
+
+        response = client.post(
+            "/api/v1/auth/reset-password",
+            json={"email": "nobody@example.com"},
+        )
+
+        assert response.status_code == 200
+        assert "reset link" in response.json()["message"].lower()
+
+    def test_reset_password_validates_email_format(self, client):
+        response = client.post(
+            "/api/v1/auth/reset-password",
+            json={"email": "not-an-email"},
+        )
+
+        assert response.status_code == 422
+
+    def test_reset_password_requires_email(self, client):
+        response = client.post(
+            "/api/v1/auth/reset-password",
+            json={},
+        )
+
+        assert response.status_code == 422
+
+
+# ─── Password Reset Confirm ───────────────────────────────────────────────────
+
+
+class TestPasswordResetConfirm:
+    """Tests for POST /api/v1/auth/reset-password/confirm."""
+
+    @patch("app.auth.router.httpx.AsyncClient")
+    def test_confirm_reset_success(self, mock_async_client_cls, client):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"id": "user-123"}
+
+        mock_http_client = AsyncMock()
+        mock_http_client.put.return_value = mock_response
+
+        mock_async_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_http_client)
+        mock_async_client_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        response = client.post(
+            "/api/v1/auth/reset-password/confirm",
+            json={
+                "access_token": "valid-reset-token",
+                "new_password": "newpassword123",
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json()["message"] == "Password updated successfully"
+
+    @patch("app.auth.router.httpx.AsyncClient")
+    def test_confirm_reset_invalid_token(self, mock_async_client_cls, client):
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        mock_response.json.return_value = {"message": "Invalid or expired token"}
+
+        mock_http_client = AsyncMock()
+        mock_http_client.put.return_value = mock_response
+
+        mock_async_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_http_client)
+        mock_async_client_cls.return_value.__aexit__ = AsyncMock(return_value=None)
+
+        response = client.post(
+            "/api/v1/auth/reset-password/confirm",
+            json={
+                "access_token": "expired-token",
+                "new_password": "newpassword123",
+            },
+        )
+
+        assert response.status_code == 400
+
+    def test_confirm_reset_requires_both_fields(self, client):
+        response = client.post(
+            "/api/v1/auth/reset-password/confirm",
+            json={"access_token": "some-token"},
+        )
+        assert response.status_code == 422
+
+        response = client.post(
+            "/api/v1/auth/reset-password/confirm",
+            json={"new_password": "some-password"},
+        )
+        assert response.status_code == 422
+
+    def test_confirm_reset_empty_body(self, client):
+        response = client.post(
+            "/api/v1/auth/reset-password/confirm",
+            json={},
+        )
+        assert response.status_code == 422

--- a/frontend/src/app/(app)/dashboard/page.tsx
+++ b/frontend/src/app/(app)/dashboard/page.tsx
@@ -11,6 +11,7 @@ import {
   type ProfileDirectoryResponse,
 } from "@/lib/api";
 import { Aurora } from "@/components/aurora";
+import { signOutUser } from "@/lib/signout";
 import { ModalBottomSheet } from "@/components/modal-bottom-sheet";
 import { ConfirmationDialog } from "@/components/confirmation-dialog";
 import { AttendeeContent, AttendeeControls, type AttendeeEventItem } from "./attendee-dashboard";
@@ -186,8 +187,7 @@ export default function DashboardPage() {
   }, [discoverEvents, discoverSearchText, myEvents]);
 
   async function handleSignOut() {
-    const supabase = createClient();
-    await supabase.auth.signOut();
+    await signOutUser();
     router.push("/");
     router.refresh();
   }

--- a/frontend/src/app/(app)/profile/page.tsx
+++ b/frontend/src/app/(app)/profile/page.tsx
@@ -15,7 +15,6 @@ import {
   GraduationCap,
   Pencil,
   LogOut,
-  KeyRound,
 } from "lucide-react";
 import { signOutUser } from "@/lib/signout";
 
@@ -28,8 +27,6 @@ export default function ProfilePage() {
   const [saving, setSaving] = useState(false);
   const [photoLoading, setPhotoLoading] = useState(false);
   const [confirmingSignOut, setConfirmingSignOut] = useState(false);
-  const [passwordResetSent, setPasswordResetSent] = useState(false);
-  const [passwordResetLoading, setPasswordResetLoading] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   async function handleSignOut() {
@@ -374,53 +371,6 @@ export default function ProfilePage() {
             )}
           </SectionCard>
         </div>
-
-        <div className="mt-6">
-            {passwordResetSent ? (
-              <p className="text-center text-[13px] text-white/40">
-                Password reset link sent to your email.
-              </p>
-            ) : (
-              <button
-                onClick={async () => {
-                  setPasswordResetLoading(true);
-                  try {
-                    const supabase = createClient();
-                    const {
-                      data: { session },
-                    } = await supabase.auth.getSession();
-                    if (!session?.user?.email) return;
-                    await fetch(
-                      `${process.env.NEXT_PUBLIC_API_URL ?? ""}/api/v1/auth/reset-password`,
-                      {
-                        method: "POST",
-                        headers: {
-                          "Content-Type": "application/json",
-                          Authorization: `Bearer ${session.access_token}`,
-                        },
-                        body: JSON.stringify({
-                          email: session.user.email,
-                          redirect_to: `${window.location.origin}/auth/callback?next=/reset-password`,
-                        }),
-                      },
-                    );
-                    setPasswordResetSent(true);
-                  } finally {
-                    setPasswordResetLoading(false);
-                  }
-                }}
-                disabled={passwordResetLoading}
-                className="flex w-full items-center justify-center gap-2 py-2 text-[13px] text-white/25 active:text-white/50"
-              >
-                {passwordResetLoading ? (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                ) : (
-                  <KeyRound className="h-3.5 w-3.5" />
-                )}
-                Forgot Password
-              </button>
-            )}
-          </div>
 
         {confirmingSignOut ? (
           <div className="mt-6 flex items-center justify-center gap-3">

--- a/frontend/src/app/(app)/profile/page.tsx
+++ b/frontend/src/app/(app)/profile/page.tsx
@@ -15,6 +15,7 @@ import {
   GraduationCap,
   Pencil,
   LogOut,
+  KeyRound,
 } from "lucide-react";
 import { signOutUser } from "@/lib/signout";
 
@@ -27,6 +28,9 @@ export default function ProfilePage() {
   const [saving, setSaving] = useState(false);
   const [photoLoading, setPhotoLoading] = useState(false);
   const [confirmingSignOut, setConfirmingSignOut] = useState(false);
+  const [isEmailUser, setIsEmailUser] = useState(false);
+  const [passwordResetSent, setPasswordResetSent] = useState(false);
+  const [passwordResetLoading, setPasswordResetLoading] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   async function handleSignOut() {
@@ -43,6 +47,12 @@ export default function ProfilePage() {
       } = await supabase.auth.getSession();
       if (!session) return;
       api.setToken(session.access_token);
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (user?.app_metadata?.provider === "email") {
+        setIsEmailUser(true);
+      }
       try {
         const p = await api.getProfile();
         setProfile(p);
@@ -371,6 +381,60 @@ export default function ProfilePage() {
             )}
           </SectionCard>
         </div>
+
+        {isEmailUser && (
+          <div className="mt-6">
+            {passwordResetSent ? (
+              <p className="text-center text-[13px] text-white/40">
+                Password reset link sent to your email.
+              </p>
+            ) : (
+              <button
+                onClick={async () => {
+                  setPasswordResetLoading(true);
+                  try {
+                    const supabase = createClient();
+                    const {
+                      data: { user },
+                    } = await supabase.auth.getUser();
+                    if (!user?.email) return;
+                    const {
+                      data: { session },
+                    } = await supabase.auth.getSession();
+                    await fetch(
+                      `${process.env.NEXT_PUBLIC_API_URL ?? ""}/api/v1/auth/reset-password`,
+                      {
+                        method: "POST",
+                        headers: {
+                          "Content-Type": "application/json",
+                          ...(session?.access_token
+                            ? { Authorization: `Bearer ${session.access_token}` }
+                            : {}),
+                        },
+                        body: JSON.stringify({
+                          email: user.email,
+                          redirect_to: `${window.location.origin}/auth/callback?next=/reset-password`,
+                        }),
+                      },
+                    );
+                    setPasswordResetSent(true);
+                  } finally {
+                    setPasswordResetLoading(false);
+                  }
+                }}
+                disabled={passwordResetLoading}
+                className="flex w-full items-center justify-center gap-2 py-2 text-[13px] text-white/25 active:text-white/50"
+              >
+                {passwordResetLoading ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <KeyRound className="h-3.5 w-3.5" />
+                )}
+                Change Password
+              </button>
+            )}
+          </div>
+        )}
 
         {confirmingSignOut ? (
           <div className="mt-6 flex items-center justify-center gap-3">

--- a/frontend/src/app/(app)/profile/page.tsx
+++ b/frontend/src/app/(app)/profile/page.tsx
@@ -28,7 +28,6 @@ export default function ProfilePage() {
   const [saving, setSaving] = useState(false);
   const [photoLoading, setPhotoLoading] = useState(false);
   const [confirmingSignOut, setConfirmingSignOut] = useState(false);
-  const [isEmailUser, setIsEmailUser] = useState(false);
   const [passwordResetSent, setPasswordResetSent] = useState(false);
   const [passwordResetLoading, setPasswordResetLoading] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -47,12 +46,6 @@ export default function ProfilePage() {
       } = await supabase.auth.getSession();
       if (!session) return;
       api.setToken(session.access_token);
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (user?.app_metadata?.provider === "email") {
-        setIsEmailUser(true);
-      }
       try {
         const p = await api.getProfile();
         setProfile(p);
@@ -382,8 +375,7 @@ export default function ProfilePage() {
           </SectionCard>
         </div>
 
-        {isEmailUser && (
-          <div className="mt-6">
+        <div className="mt-6">
             {passwordResetSent ? (
               <p className="text-center text-[13px] text-white/40">
                 Password reset link sent to your email.
@@ -395,24 +387,19 @@ export default function ProfilePage() {
                   try {
                     const supabase = createClient();
                     const {
-                      data: { user },
-                    } = await supabase.auth.getUser();
-                    if (!user?.email) return;
-                    const {
                       data: { session },
                     } = await supabase.auth.getSession();
+                    if (!session?.user?.email) return;
                     await fetch(
                       `${process.env.NEXT_PUBLIC_API_URL ?? ""}/api/v1/auth/reset-password`,
                       {
                         method: "POST",
                         headers: {
                           "Content-Type": "application/json",
-                          ...(session?.access_token
-                            ? { Authorization: `Bearer ${session.access_token}` }
-                            : {}),
+                          Authorization: `Bearer ${session.access_token}`,
                         },
                         body: JSON.stringify({
-                          email: user.email,
+                          email: session.user.email,
                           redirect_to: `${window.location.origin}/auth/callback?next=/reset-password`,
                         }),
                       },
@@ -430,11 +417,10 @@ export default function ProfilePage() {
                 ) : (
                   <KeyRound className="h-3.5 w-3.5" />
                 )}
-                Change Password
+                Forgot Password
               </button>
             )}
           </div>
-        )}
 
         {confirmingSignOut ? (
           <div className="mt-6 flex items-center justify-center gap-3">

--- a/frontend/src/app/(app)/profile/page.tsx
+++ b/frontend/src/app/(app)/profile/page.tsx
@@ -16,6 +16,7 @@ import {
   Pencil,
   LogOut,
 } from "lucide-react";
+import { signOutUser } from "@/lib/signout";
 
 export default function ProfilePage() {
   const router = useRouter();
@@ -29,8 +30,7 @@ export default function ProfilePage() {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   async function handleSignOut() {
-    const supabase = createClient();
-    await supabase.auth.signOut();
+    await signOutUser();
     router.push("/");
     router.refresh();
   }

--- a/frontend/src/app/(app)/recognition/page.tsx
+++ b/frontend/src/app/(app)/recognition/page.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/lib/api";
 import { getCachedEventConsent, setCachedEventConsent } from "@/lib/consent-cache";
 import { Aurora } from "@/components/aurora";
+import { signOutUser } from "@/lib/signout";
 import { Camera, LogOut, ScanFace, Square } from "lucide-react";
 import { SocketClient, type SocketMessage, type ProfileCard } from "@/lib/socket";
 
@@ -356,8 +357,7 @@ export default function RecognitionPage() {
   }
 
   async function handleSignOut() {
-    const supabase = createClient();
-    await supabase.auth.signOut();
+    await signOutUser();
     router.push("/");
     router.refresh();
   }

--- a/frontend/src/app/(auth)/forgot-password/page.tsx
+++ b/frontend/src/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import Link from "next/link";
+import { Loader2, ChevronLeft, ChevronRight, Mail, CheckCircle } from "lucide-react";
+import { Aurora } from "@/components/aurora";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [sent, setSent] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    requestAnimationFrame(() => inputRef.current?.focus());
+  }, []);
+
+  async function handleSubmit(e?: React.FormEvent) {
+    e?.preventDefault();
+    if (!email.trim()) return;
+
+    setError(null);
+    setLoading(true);
+
+    try {
+      const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? window.location.origin;
+      const res = await fetch(`${API_URL}/api/v1/auth/reset-password`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: email.trim(),
+          redirect_to: `${siteUrl}/auth/callback?next=/reset-password`,
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.detail || "Something went wrong");
+      }
+
+      setSent(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const color = [100, 75, 240] as const;
+  const [cr, cg, cb] = color;
+
+  if (sent) {
+    return (
+      <div
+        className="relative flex min-h-dvh flex-col items-center justify-center overflow-hidden px-6"
+        style={{
+          background: [
+            "radial-gradient(ellipse 80% 50% at 50% 20%, oklch(0.22 0.14 275) 0%, transparent 100%)",
+            "oklch(0.07 0.015 270)",
+          ].join(", "),
+        }}
+      >
+        <div className="absolute inset-0" style={{ opacity: 0.35 }}>
+          <Aurora className="h-full w-full" mode="focused" />
+        </div>
+
+        <div className="relative z-10 flex flex-col items-center text-center">
+          <div
+            className="mb-6 flex h-16 w-16 items-center justify-center rounded-full"
+            style={{
+              background: "rgba(100,75,240,0.12)",
+              border: "1.5px solid rgba(100,75,240,0.3)",
+            }}
+          >
+            <CheckCircle className="h-7 w-7 text-[rgba(100,75,240,0.8)]" />
+          </div>
+
+          <h1
+            className="mb-3 text-white"
+            style={{
+              fontFamily: "var(--font-serif)",
+              fontSize: 28,
+              fontWeight: 400,
+              letterSpacing: "-0.02em",
+            }}
+          >
+            Check your email
+          </h1>
+
+          <p className="mb-2 max-w-[280px] text-[15px] leading-relaxed text-white/45">
+            We sent a password reset link to
+          </p>
+          <p className="mb-6 text-[15px] font-medium text-white/70">
+            {email}
+          </p>
+          <p className="mb-8 max-w-[280px] text-[13px] leading-relaxed text-white/30">
+            Click the link in the email to set a new password. If you don&apos;t see it, check your spam folder.
+          </p>
+
+          <button
+            onClick={() => {
+              setSent(false);
+              setEmail("");
+            }}
+            className="flex items-center gap-2 rounded-full px-5 py-2.5 text-[13px] font-medium text-white/50 transition-all active:scale-95"
+            style={{
+              background: "rgba(255,255,255,0.04)",
+              border: "1px solid rgba(255,255,255,0.08)",
+            }}
+          >
+            <Mail className="h-3.5 w-3.5" />
+            Try a different email
+          </button>
+
+          <Link
+            href="/login"
+            className="mt-8 text-[13px] text-white/25 active:text-white/50"
+          >
+            Back to sign in
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="animate-page-in relative flex min-h-dvh flex-col overflow-hidden"
+      style={{
+        background: [
+          "radial-gradient(ellipse 80% 50% at 50% 20%, oklch(0.22 0.14 275) 0%, transparent 100%)",
+          "radial-gradient(ellipse 50% 35% at 65% 50%, oklch(0.14 0.09 240) 0%, transparent 100%)",
+          "oklch(0.07 0.015 270)",
+        ].join(", "),
+      }}
+    >
+      <div className="absolute inset-0" style={{ opacity: 0.45 }}>
+        <Aurora className="h-full w-full" mode="focused" />
+      </div>
+
+      <div className="animate-fade-in relative z-10 px-6 pt-4">
+        <Link
+          href="/login"
+          className="inline-flex h-[44px] items-center text-white/30 active:text-white/60"
+        >
+          <ChevronLeft className="h-5 w-5" />
+        </Link>
+      </div>
+
+      <div className="relative z-10 flex flex-1 flex-col items-center justify-center px-6">
+        <div className="w-full max-w-sm">
+          <div className="mb-8 text-center">
+            <h1
+              className="mb-2 text-white"
+              style={{
+                fontFamily: "var(--font-serif)",
+                fontSize: 28,
+                fontWeight: 400,
+                letterSpacing: "-0.02em",
+              }}
+            >
+              Reset password
+            </h1>
+            <p className="text-[14px] text-white/40">
+              Enter your email and we&apos;ll send you a reset link
+            </p>
+          </div>
+
+          <form onSubmit={handleSubmit}>
+            <div
+              className="mb-4 overflow-hidden rounded-2xl"
+              style={{
+                background: "rgba(255,255,255,0.04)",
+                border: `1px solid rgba(${cr},${cg},${cb}, 0.15)`,
+                boxShadow: `0 0 40px rgba(${cr},${cg},${cb}, 0.06)`,
+              }}
+            >
+              <div className="flex items-center gap-2.5 px-4 pt-3 pb-1">
+                <div
+                  className="h-2 w-2 rounded-full"
+                  style={{
+                    background: `rgba(${cr},${cg},${cb}, 0.7)`,
+                    boxShadow: `0 0 6px rgba(${cr},${cg},${cb}, 0.45)`,
+                  }}
+                />
+                <span
+                  className="text-[10px] font-semibold uppercase tracking-[0.14em]"
+                  style={{ color: `rgba(${cr},${cg},${cb}, 0.5)` }}
+                >
+                  Email
+                </span>
+              </div>
+              <div className="flex items-center px-4 pb-3.5">
+                <input
+                  ref={inputRef}
+                  type="email"
+                  placeholder="you@example.com"
+                  autoComplete="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") handleSubmit();
+                  }}
+                  className="flex-1 bg-transparent text-[16px] text-white outline-none placeholder:text-white/15"
+                  style={{ caretColor: `rgba(${cr},${cg},${cb}, 0.7)` }}
+                />
+                <button
+                  type="submit"
+                  disabled={!email.trim() || loading}
+                  className="ml-2 flex h-7 w-7 shrink-0 items-center justify-center rounded-full transition-all active:scale-90"
+                  style={{
+                    background: `rgba(${cr},${cg},${cb}, ${email.trim() ? 0.22 : 0.07})`,
+                    border: `1px solid rgba(${cr},${cg},${cb}, ${email.trim() ? 0.45 : 0.18})`,
+                    boxShadow: email.trim() ? `0 0 12px rgba(${cr},${cg},${cb}, 0.2)` : "none",
+                    transition: "all 0.3s cubic-bezier(0.16,1,0.3,1)",
+                  }}
+                >
+                  {loading ? (
+                    <Loader2
+                      className="h-3.5 w-3.5 animate-spin"
+                      style={{ color: `rgba(${cr},${cg},${cb}, 0.7)` }}
+                    />
+                  ) : (
+                    <ChevronRight
+                      className="h-3.5 w-3.5"
+                      style={{ color: `rgba(${cr},${cg},${cb}, 0.75)` }}
+                    />
+                  )}
+                </button>
+              </div>
+            </div>
+          </form>
+
+          {error && (
+            <p className="mb-4 text-center text-[13px] text-red-400/80">
+              {error}
+            </p>
+          )}
+
+          <p className="text-center text-[12px] text-white/18">
+            Remember your password?{" "}
+            <Link
+              href="/login"
+              className="font-semibold text-white/35 active:text-white/60"
+            >
+              Sign in
+            </Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/(auth)/forgot-password/page.tsx
+++ b/frontend/src/app/(auth)/forgot-password/page.tsx
@@ -32,7 +32,7 @@ export default function ForgotPasswordPage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           email: email.trim(),
-          redirect_to: `${siteUrl}/auth/callback?next=/reset-password`,
+          redirect_to: `${siteUrl}/reset-password`,
         }),
       });
 

--- a/frontend/src/app/(auth)/reset-password/page.tsx
+++ b/frontend/src/app/(auth)/reset-password/page.tsx
@@ -1,33 +1,35 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, Suspense } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
-import { Loader2, ChevronLeft, ChevronRight } from "lucide-react";
+import { Loader2, ChevronLeft, ChevronRight, CheckCircle, AlertCircle } from "lucide-react";
 import { Aurora } from "@/components/aurora";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
 
 const FIELDS = [
   {
-    key: "email",
-    label: "Email",
-    type: "email" as const,
-    placeholder: "you@example.com",
-    autoComplete: "email",
+    key: "password",
+    label: "New Password",
+    type: "password" as const,
+    placeholder: "At least 6 characters",
+    autoComplete: "new-password",
     color: [100, 75, 240] as const,
     glow: "rgba(100,75,240,0.45)",
-    pos: { left: 24, top: 40 },
+    pos: { left: 30, top: 40 },
     float: "float-2 15s ease-in-out infinite",
   },
   {
-    key: "password",
-    label: "Password",
+    key: "confirm_password",
+    label: "Confirm Password",
     type: "password" as const,
-    placeholder: "Your password",
-    autoComplete: "current-password",
+    placeholder: "Repeat password",
+    autoComplete: "new-password",
     color: [70, 110, 230] as const,
     glow: "rgba(70,110,230,0.45)",
-    pos: { left: 68, top: 52 },
+    pos: { left: 65, top: 52 },
     float: "float-3 14s ease-in-out infinite",
   },
 ];
@@ -39,21 +41,29 @@ function displayValue(val: string, type: string) {
   return val;
 }
 
-export default function LoginPage() {
+export default function ResetPasswordPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-dvh items-center justify-center" style={{ background: "oklch(0.07 0.015 270)" }}>
+          <Loader2 className="h-6 w-6 animate-spin text-white/30" />
+        </div>
+      }
+    >
+      <ResetPasswordContent />
+    </Suspense>
+  );
+}
+
+function ResetPasswordContent() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [values, setValues] = useState(["", ""]);
   const [activeIdx, setActiveIdx] = useState<number>(0);
-
-  // Continue the zoom from wherever the "You" dot was on the welcome page
-  const [enterOrigin] = useState<string>(() => {
-    if (typeof window === "undefined") return "50% 35%";
-    const stored = sessionStorage.getItem("zoomOrigin");
-    if (stored) { sessionStorage.removeItem("zoomOrigin"); return stored; }
-    return "50% 35%";
-  });
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-  const [googleLoading, setGoogleLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [tokenError, setTokenError] = useState(false);
 
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const dotRef = useRef<HTMLDivElement>(null);
@@ -68,12 +78,43 @@ export default function LoginPage() {
   const allFilled = values.every((v) => v.length > 0);
   const isLastField = activeIdx === FIELDS.length - 1;
 
-  // Auto-focus on mount and on field change
+  useEffect(() => {
+    async function extractToken() {
+      if (typeof window === "undefined") return;
+
+      const hash = window.location.hash;
+      if (hash && hash.includes("access_token")) {
+        const params = new URLSearchParams(hash.substring(1));
+        const accessToken = params.get("access_token");
+        const refreshToken = params.get("refresh_token");
+
+        if (accessToken && refreshToken) {
+          const supabase = createClient();
+          const { error } = await supabase.auth.setSession({
+            access_token: accessToken,
+            refresh_token: refreshToken,
+          });
+          if (error) {
+            setTokenError(true);
+          }
+          return;
+        }
+      }
+
+      const supabase = createClient();
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) {
+        setTokenError(true);
+      }
+    }
+
+    extractToken();
+  }, [searchParams]);
+
   useEffect(() => {
     requestAnimationFrame(() => inputRef.current?.focus());
   }, [activeIdx]);
 
-  // Canvas constellation lines
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
@@ -170,34 +211,171 @@ export default function LoginPage() {
   }, []);
 
   async function handleSubmit() {
-    setError(null);
-    setLoading(true);
-    const supabase = createClient();
-    const { error } = await supabase.auth.signInWithPassword({
-      email: values[0],
-      password: values[1],
-    });
-    if (error) {
-      setError(error.message);
-      setLoading(false);
+    if (values[0] !== values[1]) {
+      setError("Passwords do not match");
       return;
     }
-    router.push("/onboarding");
-    router.refresh();
+
+    if (values[0].length < 6) {
+      setError("Password must be at least 6 characters");
+      return;
+    }
+
+    setError(null);
+    setLoading(true);
+
+    try {
+      const supabase = createClient();
+      const { data: { session } } = await supabase.auth.getSession();
+
+      if (!session?.access_token) {
+        setTokenError(true);
+        setLoading(false);
+        return;
+      }
+
+      const res = await fetch(`${API_URL}/api/v1/auth/reset-password/confirm`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          access_token: session.access_token,
+          new_password: values[0],
+        }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.detail || "Failed to reset password");
+      }
+
+      await supabase.auth.signOut();
+      setSuccess(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setLoading(false);
+    }
   }
 
-  async function handleGoogle() {
-    setError(null);
-    setGoogleLoading(true);
-    const supabase = createClient();
-    const { error } = await supabase.auth.signInWithOAuth({
-      provider: "google",
-      options: { redirectTo: `${process.env.NEXT_PUBLIC_SITE_URL ?? window.location.origin}/auth/callback` },
-    });
-    if (error) {
-      setError(error.message);
-      setGoogleLoading(false);
-    }
+  if (tokenError) {
+    return (
+      <div
+        className="relative flex min-h-dvh flex-col items-center justify-center overflow-hidden px-6"
+        style={{
+          background: [
+            "radial-gradient(ellipse 80% 50% at 50% 20%, oklch(0.22 0.14 275) 0%, transparent 100%)",
+            "oklch(0.07 0.015 270)",
+          ].join(", "),
+        }}
+      >
+        <div className="absolute inset-0" style={{ opacity: 0.35 }}>
+          <Aurora className="h-full w-full" mode="focused" />
+        </div>
+
+        <div className="relative z-10 flex flex-col items-center text-center">
+          <div
+            className="mb-6 flex h-16 w-16 items-center justify-center rounded-full"
+            style={{
+              background: "rgba(255,80,80,0.12)",
+              border: "1.5px solid rgba(255,80,80,0.3)",
+            }}
+          >
+            <AlertCircle className="h-7 w-7 text-red-400/80" />
+          </div>
+
+          <h1
+            className="mb-3 text-white"
+            style={{
+              fontFamily: "var(--font-serif)",
+              fontSize: 28,
+              fontWeight: 400,
+              letterSpacing: "-0.02em",
+            }}
+          >
+            Link expired
+          </h1>
+
+          <p className="mb-8 max-w-[280px] text-[14px] leading-relaxed text-white/40">
+            This password reset link is invalid or has expired. Please request a new one.
+          </p>
+
+          <Link
+            href="/forgot-password"
+            className="flex items-center gap-2 rounded-full px-5 py-2.5 text-[13px] font-medium text-white/70 transition-all active:scale-95"
+            style={{
+              background: "rgba(100,75,240,0.12)",
+              border: "1px solid rgba(100,75,240,0.25)",
+            }}
+          >
+            Request new link
+          </Link>
+
+          <Link
+            href="/login"
+            className="mt-6 text-[13px] text-white/25 active:text-white/50"
+          >
+            Back to sign in
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (success) {
+    return (
+      <div
+        className="relative flex min-h-dvh flex-col items-center justify-center overflow-hidden px-6"
+        style={{
+          background: [
+            "radial-gradient(ellipse 80% 50% at 50% 20%, oklch(0.22 0.14 275) 0%, transparent 100%)",
+            "oklch(0.07 0.015 270)",
+          ].join(", "),
+        }}
+      >
+        <div className="absolute inset-0" style={{ opacity: 0.35 }}>
+          <Aurora className="h-full w-full" mode="focused" />
+        </div>
+
+        <div className="relative z-10 flex flex-col items-center text-center">
+          <div
+            className="mb-6 flex h-16 w-16 items-center justify-center rounded-full"
+            style={{
+              background: "rgba(52,168,83,0.12)",
+              border: "1.5px solid rgba(52,168,83,0.3)",
+            }}
+          >
+            <CheckCircle className="h-7 w-7 text-[rgba(52,168,83,0.8)]" />
+          </div>
+
+          <h1
+            className="mb-3 text-white"
+            style={{
+              fontFamily: "var(--font-serif)",
+              fontSize: 28,
+              fontWeight: 400,
+              letterSpacing: "-0.02em",
+            }}
+          >
+            Password updated
+          </h1>
+
+          <p className="mb-8 max-w-[280px] text-[14px] leading-relaxed text-white/40">
+            Your password has been reset. You can now sign in with your new password.
+          </p>
+
+          <button
+            onClick={() => router.push("/login")}
+            className="flex h-[50px] w-full max-w-[240px] items-center justify-center gap-2 rounded-[14px] text-[14px] font-medium text-white/90 transition-all active:scale-[0.98]"
+            style={{
+              background: "oklch(1 0 0 / 6%)",
+              boxShadow: "inset 0 0 0 1px oklch(0.5 0.15 275 / 25%), 0 0 30px oklch(0.4 0.12 275 / 15%)",
+            }}
+          >
+            Sign in
+          </button>
+        </div>
+      </div>
+    );
   }
 
   const activeField = FIELDS[activeIdx];
@@ -207,7 +385,6 @@ export default function LoginPage() {
     <div
       className="animate-page-in relative flex min-h-dvh flex-col overflow-hidden"
       style={{
-        transformOrigin: enterOrigin,
         background: [
           "radial-gradient(ellipse 80% 50% at 50% 20%, oklch(0.22 0.14 275) 0%, transparent 100%)",
           "radial-gradient(ellipse 50% 35% at 65% 50%, oklch(0.14 0.09 240) 0%, transparent 100%)",
@@ -228,14 +405,13 @@ export default function LoginPage() {
 
       <div className="animate-fade-in relative z-10 px-6 pt-4">
         <Link
-          href="/"
+          href="/login"
           className="inline-flex h-[44px] items-center text-white/30 active:text-white/60"
         >
           <ChevronLeft className="h-5 w-5" />
         </Link>
       </div>
 
-      {/* Constellation */}
       <div className="relative z-10 flex-1" style={{ minHeight: "50vh" }}>
         {/* "You" dot */}
         <div
@@ -260,7 +436,7 @@ export default function LoginPage() {
             />
             <div className="h-5 w-5 rounded-full bg-white/90 shadow-[0_0_24px_rgba(255,255,255,0.4)]" />
             <span className="mt-3 text-[11px] font-semibold uppercase tracking-[0.18em] text-white/25">
-              You
+              New Password
             </span>
           </div>
         </div>
@@ -389,7 +565,7 @@ export default function LoginPage() {
           );
         })}
 
-        {/* Input panel — always visible */}
+        {/* Input panel */}
         <div
           className="absolute left-1/2"
           style={{
@@ -447,9 +623,9 @@ export default function LoginPage() {
                   caretColor: `rgba(${cr},${cg},${cb}, 0.7)`,
                 }}
               />
-              {/* Next / Submit arrow */}
               <button
                 type="button"
+                disabled={loading}
                 onPointerDown={(e) => {
                   e.preventDefault();
                   if (activeIdx < FIELDS.length - 1) {
@@ -458,7 +634,7 @@ export default function LoginPage() {
                     handleSubmit();
                   }
                 }}
-                className="ml-2 shrink-0 flex h-7 w-7 items-center justify-center rounded-full transition-all active:scale-90"
+                className="ml-2 flex h-7 w-7 shrink-0 items-center justify-center rounded-full transition-all active:scale-90"
                 style={{
                   background: `rgba(${cr},${cg},${cb}, ${isLastField && allFilled ? 0.22 : 0.07})`,
                   border: `1px solid rgba(${cr},${cg},${cb}, ${isLastField && allFilled ? 0.45 : 0.18})`,
@@ -519,72 +695,6 @@ export default function LoginPage() {
           </div>
         )}
       </div>
-
-      {/* Google + footer */}
-      <div className="relative z-10 px-6 pb-8">
-        <div className="mb-4 flex items-center gap-4">
-          <div className="h-px flex-1 bg-white/[0.05]" />
-          <span className="text-[10px] uppercase tracking-[0.1em] text-white/14">
-            or
-          </span>
-          <div className="h-px flex-1 bg-white/[0.05]" />
-        </div>
-
-        <button
-          type="button"
-          className="animate-fade-in delay-500 flex h-[50px] w-full items-center justify-center gap-3 rounded-[14px] bg-white/[0.03] text-[14px] text-white/50 ring-1 ring-white/[0.05] transition-all active:scale-[0.98] active:bg-white/[0.06]"
-          onClick={handleGoogle}
-          disabled={googleLoading}
-        >
-          {googleLoading ? (
-            <Loader2 className="h-5 w-5 animate-spin text-white/30" />
-          ) : (
-            <GoogleIcon />
-          )}
-          Continue with Google
-        </button>
-
-        <div className="animate-fade-in delay-600 mt-5 flex flex-col items-center gap-2">
-          <Link
-            href="/forgot-password"
-            className="text-[12px] text-white/25 active:text-white/50"
-          >
-            Forgot password?
-          </Link>
-          <p className="text-[12px] text-white/18">
-            New here?{" "}
-            <Link
-              href="/signup"
-              className="font-semibold text-white/35 active:text-white/60"
-            >
-              Create an account
-            </Link>
-          </p>
-        </div>
-      </div>
     </div>
-  );
-}
-
-function GoogleIcon() {
-  return (
-    <svg className="h-[18px] w-[18px]" viewBox="0 0 24 24">
-      <path
-        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
-        fill="#4285F4"
-      />
-      <path
-        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-        fill="#34A853"
-      />
-      <path
-        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-        fill="#FBBC05"
-      />
-      <path
-        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-        fill="#EA4335"
-      />
-    </svg>
   );
 }

--- a/frontend/src/app/auth/callback/route.ts
+++ b/frontend/src/app/auth/callback/route.ts
@@ -17,6 +17,11 @@ export async function GET(request: Request) {
     const supabase = await createClient();
     const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (!error) {
+      // Password reset redirects to /reset-password
+      if (next === "/reset-password") {
+        return NextResponse.redirect(`${origin}/reset-password`);
+      }
+
       const { data: { user } } = await supabase.auth.getUser();
       if (user) {
         const { data: profile } = await supabase

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { Aurora } from "@/components/aurora";
 import { SignupContent } from "@/components/signup-content";
 import { LoginContent } from "@/components/login-content";
@@ -8,6 +9,14 @@ import { LoginContent } from "@/components/login-content";
 type Screen = "welcome" | "signup" | "login";
 
 export default function App() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const hash = window.location.hash;
+    if (hash && hash.includes("type=recovery")) {
+      router.replace(`/reset-password${hash}`);
+    }
+  }, [router]);
   const [screen, setScreen] = useState<Screen>("welcome");
   const [prevScreen, setPrevScreen] = useState<Screen>("welcome");
   const [contentVisible, setContentVisible] = useState(true);

--- a/frontend/src/components/login-content.tsx
+++ b/frontend/src/components/login-content.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect, useCallback } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { api } from "@/lib/api";
@@ -436,12 +437,20 @@ export function LoginContent({ onBack, onGoSignup, showYouDot = true }: { onBack
           {googleLoading ? <Loader2 className="h-5 w-5 animate-spin text-white/30" /> : <GoogleIcon />}
           Continue with Google
         </button>
-        <p className="mt-5 text-center text-[12px] text-white/18">
-          New here?{" "}
-          <button onClick={onGoSignup} className="font-semibold text-white/35 active:text-white/60">
-            Create an account
-          </button>
-        </p>
+        <div className="mt-5 flex flex-col items-center gap-2">
+          <Link
+            href="/forgot-password"
+            className="text-[12px] text-white/25 active:text-white/50"
+          >
+            Forgot password?
+          </Link>
+          <p className="text-[12px] text-white/18">
+            New here?{" "}
+            <button onClick={onGoSignup} className="font-semibold text-white/35 active:text-white/60">
+              Create an account
+            </button>
+          </p>
+        </div>
       </div>
     </>
   );

--- a/frontend/src/components/signup-content.tsx
+++ b/frontend/src/components/signup-content.tsx
@@ -177,11 +177,11 @@ export function SignupContent({ onBack, onGoLogin, showYouDot = true }: { onBack
       },
     });
     if (error) { setError(error.message); setLoading(false); return; }
-    if (data?.session) {
+    if (data?.session === null) {
+      router.replace("/signup?verify=pending");
+    } else {
       router.replace("/onboarding");
       router.refresh();
-    } else {
-      router.replace("/signup?verify=pending");
     }
   }
 

--- a/frontend/src/components/signup-content.tsx
+++ b/frontend/src/components/signup-content.tsx
@@ -168,14 +168,21 @@ export function SignupContent({ onBack, onGoLogin, showYouDot = true }: { onBack
     setError(null);
     setLoading(true);
     const supabase = createClient();
-    const { error } = await supabase.auth.signUp({
+    const { data, error } = await supabase.auth.signUp({
       email: values[1],
       password: values[2],
-      options: { data: { full_name: values[0] } },
+      options: {
+        data: { full_name: values[0] },
+        emailRedirectTo: `${window.location.origin}/auth/callback`,
+      },
     });
     if (error) { setError(error.message); setLoading(false); return; }
-    router.replace("/onboarding");
-    router.refresh();
+    if (data.session) {
+      router.replace("/onboarding");
+      router.refresh();
+    } else {
+      router.replace("/signup?verify=pending");
+    }
   }
 
   async function handleGoogle() {

--- a/frontend/src/components/signup-content.tsx
+++ b/frontend/src/components/signup-content.tsx
@@ -177,7 +177,7 @@ export function SignupContent({ onBack, onGoLogin, showYouDot = true }: { onBack
       },
     });
     if (error) { setError(error.message); setLoading(false); return; }
-    if (data.session) {
+    if (data?.session) {
       router.replace("/onboarding");
       router.refresh();
     } else {

--- a/frontend/src/lib/signout.ts
+++ b/frontend/src/lib/signout.ts
@@ -1,0 +1,37 @@
+import { createClient } from "@/lib/supabase/client";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
+
+/**
+ * Signs out the user by:
+ * 1. Revoking the session server-side via the backend
+ * 2. Signing out of Supabase client-side
+ * 3. Clearing all client-side storage (sessionStorage, localStorage onboarding state)
+ */
+export async function signOutUser(): Promise<void> {
+  const supabase = createClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (session?.access_token) {
+    try {
+      await fetch(`${API_URL}/api/v1/auth/signout`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+          "Content-Type": "application/json",
+        },
+      });
+    } catch {
+      // Backend sign-out is best-effort; client-side cleanup still proceeds
+    }
+  }
+
+  await supabase.auth.signOut();
+
+  if (typeof window !== "undefined") {
+    sessionStorage.clear();
+    localStorage.removeItem("onboarding_missing_steps");
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a complete password reset flow: users can click "Forgot password?" on the login page, receive a reset email, and set a new password through a dedicated page
- Replaces the client-only sign-out with a server-side endpoint that revokes the Supabase session before clearing client state
- Includes 12 backend tests covering all three new endpoints
## Backend (3 new endpoints)
- `POST /auth/signout` — revokes session server-side via Supabase Admin API
- `POST /auth/reset-password` — sends password reset email (always returns success to prevent email enumeration)
- `POST /auth/reset-password/confirm` — sets new password using the access token from the reset link
## Frontend (2 new pages + shared utility)
- `/forgot-password` — email input page with confirmation UI matching the Aurora design system
- `/reset-password` — new password form with constellation UI, handles expired/invalid links gracefully
- Shared `signOutUser()` utility used by profile, dashboard, and recognition pages — calls backend to revoke session, clears Supabase client, wipes sessionStorage and localStorage
- "Forgot password?" link added to login page and home login flow
- Auth callback updated to route password reset redirects to `/reset-password`
## Test plan
- [ ] 12 automated backend tests pass (`pytest tests/test_auth_password_reset.py`)
- [ ] Visit `/forgot-password` — page renders with email input
- [ ] Visit `/login` — "Forgot password?" link is visible
- [ ] Submit email on forgot password page — reset email is received
- [ ] Click reset link — lands on `/reset-password` with password form
- [ ] Set new password — success screen shown, can sign in with new password
- [ ] Sign out from profile page — session revoked server-side, redirected to home
### Additional fix: Email verification enforcement
- **`signup-content.tsx`**: The landing page signup form was bypassing email verification — it navigated directly to `/onboarding` without checking whether Supabase returned a session. Now it checks `data.session` and redirects unverified users to `/signup?verify=pending` (the "Check your email" screen).
- Added `emailRedirectTo` to the signup options so the verification email link redirects correctly through `/auth/callback`.
- Enabled "Confirm email" in Supabase Dashboard so email-password signups require verification before access.

Closes #22, closes #23 
