### PR TITLE
Add Terms of Service Page Gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,6 +117,31 @@ jobs:
           path: backend/coverage.xml
           retention-days: 7
 
+  frontend-test:
+    name: Frontend Tests
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run frontend tests
+        run: npm test
+
   build:
     name: Build Check
     runs-on: ubuntu-latest

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,21 +21,30 @@
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@vitejs/plugin-react": "^6.0.1",
         "eslint": "^9",
         "eslint-config-next": "16.1.6",
+        "jsdom": "^29.0.2",
         "shadcn": "^3.8.5",
         "tailwindcss": "^4",
         "tw-animate-css": "^1.4.0",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^4.1.4"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
-      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -47,8 +56,6 @@
     },
     "node_modules/@antfu/ni": {
       "version": "25.0.0",
-      "resolved": "https://registry.npmjs.org/@antfu/ni/-/ni-25.0.0.tgz",
-      "integrity": "sha512-9q/yCljni37pkMr4sPrI3G4jqdIk074+iukc5aFJl7kmDCCsiJrbZ6zKxnES1Gwg+i9RcDZwvktl23puGslmvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -67,10 +74,51 @@
         "nup": "bin/nup.mjs"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.10",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -84,8 +132,6 @@
     },
     "node_modules/@babel/compat-data": {
       "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -94,10 +140,9 @@
     },
     "node_modules/@babel/core": {
       "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -125,8 +170,6 @@
     },
     "node_modules/@babel/generator": {
       "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -142,8 +185,6 @@
     },
     "node_modules/@babel/helper-annotate-as-pure": {
       "version": "7.27.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
-      "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -155,8 +196,6 @@
     },
     "node_modules/@babel/helper-compilation-targets": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -172,8 +211,6 @@
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
-      "integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -194,8 +231,6 @@
     },
     "node_modules/@babel/helper-globals": {
       "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -204,8 +239,6 @@
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
       "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
-      "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -218,8 +251,6 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -232,8 +263,6 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -250,8 +279,6 @@
     },
     "node_modules/@babel/helper-optimise-call-expression": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
-      "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -263,8 +290,6 @@
     },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -273,8 +298,6 @@
     },
     "node_modules/@babel/helper-replace-supers": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
-      "integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -291,8 +314,6 @@
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
-      "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -305,8 +326,6 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -315,8 +334,6 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -325,8 +342,6 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -334,23 +349,19 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/types": "^7.29.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -365,8 +376,6 @@
     },
     "node_modules/@babel/plugin-syntax-jsx": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
-      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -381,8 +390,6 @@
     },
     "node_modules/@babel/plugin-syntax-typescript": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
-      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -397,8 +404,6 @@
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz",
-      "integrity": "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -414,8 +419,6 @@
     },
     "node_modules/@babel/plugin-transform-typescript": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.6.tgz",
-      "integrity": "sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -434,8 +437,6 @@
     },
     "node_modules/@babel/preset-typescript": {
       "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz",
-      "integrity": "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -452,10 +453,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -469,8 +476,6 @@
     },
     "node_modules/@babel/traverse": {
       "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -488,8 +493,6 @@
     },
     "node_modules/@babel/types": {
       "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -500,10 +503,149 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@dotenvx/dotenvx": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@dotenvx/dotenvx/-/dotenvx-1.52.0.tgz",
-      "integrity": "sha512-CaQcc8JvtzQhUSm9877b6V4Tb7HCotkcyud9X2YwdqtQKwgljkMRwU96fVYKnzN3V0Hj74oP7Es+vZ0mS+Aa1w==",
+      "version": "1.61.0",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -515,7 +657,8 @@
         "ignore": "^5.3.0",
         "object-treeify": "1.1.33",
         "picomatch": "^4.0.2",
-        "which": "^4.0.0"
+        "which": "^4.0.0",
+        "yocto-spinner": "^1.1.0"
       },
       "bin": {
         "dotenvx": "src/cli/dotenvx.js"
@@ -526,8 +669,6 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/commander": {
       "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -536,8 +677,6 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/execa": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -560,8 +699,6 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -578,8 +715,6 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/get-stream": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -591,8 +726,6 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/human-signals": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -601,8 +734,6 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/is-stream": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -614,8 +745,6 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/isexe": {
       "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
-      "integrity": "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -624,8 +753,6 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/npm-run-path": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -637,8 +764,6 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/onetime": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -652,11 +777,10 @@
       }
     },
     "node_modules/@dotenvx/dotenvx/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -666,15 +790,11 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/signal-exit": {
       "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/@dotenvx/dotenvx/node_modules/strip-final-newline": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -683,8 +803,6 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/which": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
-      "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -698,46 +816,20 @@
       }
     },
     "node_modules/@ecies/ciphers": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@ecies/ciphers/-/ciphers-0.2.5.tgz",
-      "integrity": "sha512-GalEZH4JgOMHYYcYmVqnFirFsjZHeoGMDt9IxEnM9F7GRUUyUksJ7Ou53L83WHJq3RWKD3AcBpo0iQh0oMpf8A==",
+      "version": "0.2.6",
       "dev": true,
       "license": "MIT",
       "engines": {
         "bun": ">=1",
-        "deno": ">=2",
+        "deno": ">=2.7.10",
         "node": ">=16"
       },
       "peerDependencies": {
         "@noble/ciphers": "^1.0.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
-      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "version": "1.2.1",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -747,8 +839,6 @@
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -766,8 +856,6 @@
     },
     "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
       "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -779,8 +867,6 @@
     },
     "node_modules/@eslint-community/regexpp": {
       "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
-      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -788,15 +874,13 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+      "version": "0.21.2",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^3.1.5"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -804,8 +888,6 @@
     },
     "node_modules/@eslint/config-helpers": {
       "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -817,8 +899,6 @@
     },
     "node_modules/@eslint/core": {
       "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -829,9 +909,7 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.4.tgz",
-      "integrity": "sha512-4h4MVF8pmBsncB60r0wSJiIeUKTSD4m7FmTFThG8RHlsg9ajqckLm9OraguFGZE4vVdpiI1Q4+hFnisopmG6gQ==",
+      "version": "3.3.5",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -842,7 +920,7 @@
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.3",
+        "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -853,9 +931,7 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.3",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.3.tgz",
-      "integrity": "sha512-1B1VkCq6FuUNlQvlBYb+1jDu/gV297TIs/OeiaSR9l1H27SVW55ONE1e1Vp16NqP683+xEGzxYtv4XCiDPaQiw==",
+      "version": "9.39.4",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -867,8 +943,6 @@
     },
     "node_modules/@eslint/object-schema": {
       "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -877,8 +951,6 @@
     },
     "node_modules/@eslint/plugin-kit": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -889,32 +961,42 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
-      "integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
+      "version": "1.7.5",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
-      "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
+      "version": "1.7.6",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.4",
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.7.tgz",
-      "integrity": "sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg==",
+      "version": "2.1.8",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.7.5"
+        "@floating-ui/dom": "^1.7.6"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -922,15 +1004,11 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "version": "0.2.11",
       "license": "MIT"
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.14",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -942,8 +1020,6 @@
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -952,8 +1028,6 @@
     },
     "node_modules/@humanfs/node": {
       "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -966,8 +1040,6 @@
     },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
-      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -980,8 +1052,6 @@
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
-      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -993,9 +1063,7 @@
       }
     },
     "node_modules/@img/colour": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
-      "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
+      "version": "1.1.0",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -1004,8 +1072,6 @@
     },
     "node_modules/@img/sharp-darwin-arm64": {
       "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
       "cpu": [
         "arm64"
       ],
@@ -1048,8 +1114,6 @@
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
       "cpu": [
         "arm64"
       ],
@@ -1459,27 +1523,23 @@
       }
     },
     "node_modules/@inquirer/ansi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
-      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "version": "2.0.5",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "5.1.21",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
-      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "version": "6.0.11",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.3.2",
-        "@inquirer/type": "^3.0.10"
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/type": "^4.0.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -1491,23 +1551,20 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
-      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "version": "11.1.8",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^1.0.2",
-        "@inquirer/figures": "^1.0.15",
-        "@inquirer/type": "^3.0.10",
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5",
         "cli-width": "^4.1.0",
-        "mute-stream": "^2.0.0",
-        "signal-exit": "^4.1.0",
-        "wrap-ansi": "^6.2.0",
-        "yoctocolors-cjs": "^2.1.3"
+        "fast-wrap-ansi": "^0.2.0",
+        "mute-stream": "^3.0.0",
+        "signal-exit": "^4.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -1519,23 +1576,19 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
-      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "version": "2.0.5",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
-      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "version": "4.0.5",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
       },
       "peerDependencies": {
         "@types/node": ">=18"
@@ -1548,8 +1601,6 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
-      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1559,8 +1610,6 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1570,8 +1619,6 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1580,15 +1627,11 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1597,9 +1640,7 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.0.tgz",
-      "integrity": "sha512-qOdO524oPMkUsOJTrsH9vz/HN3B5pKyW+9zIW51A9kDMVe7ON70drz1ouoyoyOcfzc+oxhkQ6jWmbyKnlWmYqA==",
+      "version": "1.29.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1639,8 +1680,6 @@
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
       "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1656,15 +1695,11 @@
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@mswjs/interceptors": {
       "version": "0.41.3",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.3.tgz",
-      "integrity": "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1679,29 +1714,36 @@
         "node": ">=18"
       }
     },
+    "node_modules/@mswjs/interceptors/node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
-      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.4.3",
-        "@emnapi/runtime": "^1.4.3",
-        "@tybys/wasm-util": "^0.10.0"
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@next/env": {
       "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.6.tgz",
-      "integrity": "sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.1.6.tgz",
-      "integrity": "sha512-/Qq3PTagA6+nYVfryAtQ7/9FEr/6YVyvOtl6rZnGsbReGLf0jZU6gkpr1FuChAQpvV46a78p4cmHOVP8mbfSMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1710,8 +1752,6 @@
     },
     "node_modules/@next/swc-darwin-arm64": {
       "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.6.tgz",
-      "integrity": "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==",
       "cpu": [
         "arm64"
       ],
@@ -1838,10 +1878,9 @@
     },
     "node_modules/@noble/ciphers": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
-      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -1851,8 +1890,6 @@
     },
     "node_modules/@noble/curves": {
       "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
-      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1867,8 +1904,6 @@
     },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1880,8 +1915,6 @@
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1894,8 +1927,6 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1904,8 +1935,6 @@
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1918,8 +1947,6 @@
     },
     "node_modules/@nolyfill/is-core-module": {
       "version": "1.0.39",
-      "resolved": "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz",
-      "integrity": "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1927,16 +1954,12 @@
       }
     },
     "node_modules/@open-draft/deferred-promise": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
-      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "version": "3.0.0",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@open-draft/logger": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
-      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1946,27 +1969,27 @@
     },
     "node_modules/@open-draft/until": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
-      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.124.0",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
-      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
       "license": "MIT"
     },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
-      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
     },
     "node_modules/@radix-ui/react-accessible-icon": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-accessible-icon/-/react-accessible-icon-1.1.7.tgz",
-      "integrity": "sha512-XM+E4WXl0OqUJFovy6GjmxxFyx9opfCAIUku4dlKRd5YEPqt4kALOkQOp0Of6reHuUkJuiPBEc5k0o4z4lTC8A==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-visually-hidden": "1.2.3"
@@ -1988,8 +2011,6 @@
     },
     "node_modules/@radix-ui/react-accordion": {
       "version": "1.2.12",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-accordion/-/react-accordion-1.2.12.tgz",
-      "integrity": "sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
@@ -2019,8 +2040,6 @@
     },
     "node_modules/@radix-ui/react-alert-dialog": {
       "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
-      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
@@ -2047,8 +2066,6 @@
     },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
-      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
@@ -2070,8 +2087,6 @@
     },
     "node_modules/@radix-ui/react-aspect-ratio": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-1.1.7.tgz",
-      "integrity": "sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
@@ -2093,8 +2108,6 @@
     },
     "node_modules/@radix-ui/react-avatar": {
       "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.1.10.tgz",
-      "integrity": "sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-context": "1.1.2",
@@ -2120,8 +2133,6 @@
     },
     "node_modules/@radix-ui/react-checkbox": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-1.3.3.tgz",
-      "integrity": "sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
@@ -2150,8 +2161,6 @@
     },
     "node_modules/@radix-ui/react-collapsible": {
       "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.12.tgz",
-      "integrity": "sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
@@ -2180,8 +2189,6 @@
     },
     "node_modules/@radix-ui/react-collection": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
-      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2",
@@ -2206,8 +2213,6 @@
     },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
-      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2221,8 +2226,6 @@
     },
     "node_modules/@radix-ui/react-context": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2236,8 +2239,6 @@
     },
     "node_modules/@radix-ui/react-context-menu": {
       "version": "2.2.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.2.16.tgz",
-      "integrity": "sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
@@ -2264,8 +2265,6 @@
     },
     "node_modules/@radix-ui/react-dialog": {
       "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
-      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
@@ -2300,8 +2299,6 @@
     },
     "node_modules/@radix-ui/react-direction": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
-      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2315,8 +2312,6 @@
     },
     "node_modules/@radix-ui/react-dismissable-layer": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
-      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
@@ -2342,8 +2337,6 @@
     },
     "node_modules/@radix-ui/react-dropdown-menu": {
       "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
-      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
@@ -2371,8 +2364,6 @@
     },
     "node_modules/@radix-ui/react-focus-guards": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
-      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2386,8 +2377,6 @@
     },
     "node_modules/@radix-ui/react-focus-scope": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
-      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2",
@@ -2411,8 +2400,6 @@
     },
     "node_modules/@radix-ui/react-form": {
       "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-form/-/react-form-0.1.8.tgz",
-      "integrity": "sha512-QM70k4Zwjttifr5a4sZFts9fn8FzHYvQ5PiB19O2HsYibaHSVt9fH9rzB0XZo/YcM+b7t/p7lYCT/F5eOeF5yQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
@@ -2439,8 +2426,6 @@
     },
     "node_modules/@radix-ui/react-hover-card": {
       "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-hover-card/-/react-hover-card-1.1.15.tgz",
-      "integrity": "sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
@@ -2470,8 +2455,6 @@
     },
     "node_modules/@radix-ui/react-id": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
-      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.1"
@@ -2488,8 +2471,6 @@
     },
     "node_modules/@radix-ui/react-label": {
       "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
-      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
@@ -2511,8 +2492,6 @@
     },
     "node_modules/@radix-ui/react-menu": {
       "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
-      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
@@ -2551,8 +2530,6 @@
     },
     "node_modules/@radix-ui/react-menubar": {
       "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-menubar/-/react-menubar-1.1.16.tgz",
-      "integrity": "sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
@@ -2583,8 +2560,6 @@
     },
     "node_modules/@radix-ui/react-navigation-menu": {
       "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-navigation-menu/-/react-navigation-menu-1.2.14.tgz",
-      "integrity": "sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
@@ -2619,8 +2594,6 @@
     },
     "node_modules/@radix-ui/react-one-time-password-field": {
       "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-one-time-password-field/-/react-one-time-password-field-0.1.8.tgz",
-      "integrity": "sha512-ycS4rbwURavDPVjCb5iS3aG4lURFDILi6sKI/WITUMZ13gMmn/xGjpLoqBAalhJaDk8I3UbCM5GzKHrnzwHbvg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/number": "1.1.1",
@@ -2653,8 +2626,6 @@
     },
     "node_modules/@radix-ui/react-password-toggle-field": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-password-toggle-field/-/react-password-toggle-field-0.1.3.tgz",
-      "integrity": "sha512-/UuCrDBWravcaMix4TdT+qlNdVwOM1Nck9kWx/vafXsdfj1ChfhOdfi3cy9SGBpWgTXwYCuboT/oYpJy3clqfw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
@@ -2683,8 +2654,6 @@
     },
     "node_modules/@radix-ui/react-popover": {
       "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
-      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
@@ -2720,8 +2689,6 @@
     },
     "node_modules/@radix-ui/react-popper": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
-      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.0",
@@ -2752,8 +2719,6 @@
     },
     "node_modules/@radix-ui/react-portal": {
       "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
-      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3",
@@ -2776,8 +2741,6 @@
     },
     "node_modules/@radix-ui/react-presence": {
       "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
-      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2",
@@ -2800,8 +2763,6 @@
     },
     "node_modules/@radix-ui/react-primitive": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.2.3"
@@ -2823,8 +2784,6 @@
     },
     "node_modules/@radix-ui/react-progress": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.7.tgz",
-      "integrity": "sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-context": "1.1.2",
@@ -2847,8 +2806,6 @@
     },
     "node_modules/@radix-ui/react-radio-group": {
       "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
-      "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
@@ -2879,8 +2836,6 @@
     },
     "node_modules/@radix-ui/react-roving-focus": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
-      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
@@ -2910,8 +2865,6 @@
     },
     "node_modules/@radix-ui/react-scroll-area": {
       "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz",
-      "integrity": "sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/number": "1.1.1",
@@ -2941,8 +2894,6 @@
     },
     "node_modules/@radix-ui/react-select": {
       "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.2.6.tgz",
-      "integrity": "sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/number": "1.1.1",
@@ -2984,8 +2935,6 @@
     },
     "node_modules/@radix-ui/react-separator": {
       "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.1.7.tgz",
-      "integrity": "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
@@ -3007,8 +2956,6 @@
     },
     "node_modules/@radix-ui/react-slider": {
       "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.6.tgz",
-      "integrity": "sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/number": "1.1.1",
@@ -3040,8 +2987,6 @@
     },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"
@@ -3058,8 +3003,6 @@
     },
     "node_modules/@radix-ui/react-switch": {
       "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
-      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
@@ -3087,8 +3030,6 @@
     },
     "node_modules/@radix-ui/react-tabs": {
       "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
-      "integrity": "sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
@@ -3117,8 +3058,6 @@
     },
     "node_modules/@radix-ui/react-toast": {
       "version": "1.2.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.2.15.tgz",
-      "integrity": "sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
@@ -3151,8 +3090,6 @@
     },
     "node_modules/@radix-ui/react-toggle": {
       "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
-      "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
@@ -3176,8 +3113,6 @@
     },
     "node_modules/@radix-ui/react-toggle-group": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle-group/-/react-toggle-group-1.1.11.tgz",
-      "integrity": "sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
@@ -3205,8 +3140,6 @@
     },
     "node_modules/@radix-ui/react-toolbar": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-toolbar/-/react-toolbar-1.1.11.tgz",
-      "integrity": "sha512-4ol06/1bLoFu1nwUqzdD4Y5RZ9oDdKeiHIsntug54Hcr1pgaHiPqHFEaXI1IFP/EsOfROQZ8Mig9VTIRza6Tjg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
@@ -3234,8 +3167,6 @@
     },
     "node_modules/@radix-ui/react-tooltip": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
-      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
@@ -3268,8 +3199,6 @@
     },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
-      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -3283,8 +3212,6 @@
     },
     "node_modules/@radix-ui/react-use-controllable-state": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
-      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-effect-event": "0.0.2",
@@ -3302,8 +3229,6 @@
     },
     "node_modules/@radix-ui/react-use-effect-event": {
       "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
-      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.1"
@@ -3320,8 +3245,6 @@
     },
     "node_modules/@radix-ui/react-use-escape-keydown": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
-      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-callback-ref": "1.1.1"
@@ -3338,8 +3261,6 @@
     },
     "node_modules/@radix-ui/react-use-is-hydrated": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-is-hydrated/-/react-use-is-hydrated-0.1.0.tgz",
-      "integrity": "sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==",
       "license": "MIT",
       "dependencies": {
         "use-sync-external-store": "^1.5.0"
@@ -3356,8 +3277,6 @@
     },
     "node_modules/@radix-ui/react-use-layout-effect": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
-      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -3371,8 +3290,6 @@
     },
     "node_modules/@radix-ui/react-use-previous": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
-      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -3386,8 +3303,6 @@
     },
     "node_modules/@radix-ui/react-use-rect": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
-      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/rect": "1.1.1"
@@ -3404,8 +3319,6 @@
     },
     "node_modules/@radix-ui/react-use-size": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
-      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.1"
@@ -3422,8 +3335,6 @@
     },
     "node_modules/@radix-ui/react-visually-hidden": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
-      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
@@ -3445,28 +3356,303 @@
     },
     "node_modules/@radix-ui/rect": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
-      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "license": "MIT"
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.15",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.7",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
-      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
-      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
-      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3476,10 +3662,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@supabase/auth-js": {
-      "version": "2.97.0",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.97.0.tgz",
-      "integrity": "sha512-2Og/1lqp+AIavr8qS2X04aSl8RBY06y4LrtIAGxat06XoXYiDxKNQMQzWDAKm1EyZFZVRNH48DO5YvIZ7la5fQ==",
+      "version": "2.103.3",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -3489,9 +3678,7 @@
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.97.0",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.97.0.tgz",
-      "integrity": "sha512-fSaA0ZeBUS9hMgpGZt5shIZvfs3Mvx2ZdajQT4kv/whubqDBAp3GU5W8iIXy21MRvKmO2NpAj8/Q6y+ZkZyF/w==",
+      "version": "2.103.3",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -3500,10 +3687,12 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.0",
+      "license": "MIT"
+    },
     "node_modules/@supabase/postgrest-js": {
-      "version": "2.97.0",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.97.0.tgz",
-      "integrity": "sha512-g4Ps0eaxZZurvfv/KGoo2XPZNpyNtjth9aW8eho9LZWM0bUuBtxPZw3ZQ6ERSpEGogshR+XNgwlSPIwcuHCNww==",
+      "version": "2.103.3",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -3513,12 +3702,10 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.97.0",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.97.0.tgz",
-      "integrity": "sha512-37Jw0NLaFP0CZd7qCan97D1zWutPrTSpgWxAw6Yok59JZoxp4IIKMrPeftJ3LZHmf+ILQOPy3i0pRDHM9FY36Q==",
+      "version": "2.103.3",
       "license": "MIT",
       "dependencies": {
-        "@types/phoenix": "^1.6.6",
+        "@supabase/phoenix": "^0.4.0",
         "@types/ws": "^8.18.1",
         "tslib": "2.8.1",
         "ws": "^8.18.2"
@@ -3529,8 +3716,6 @@
     },
     "node_modules/@supabase/ssr": {
       "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.8.0.tgz",
-      "integrity": "sha512-/PKk8kNFSs8QvvJ2vOww1mF5/c5W8y42duYtXvkOSe+yZKRgTTZywYG2l41pjhNomqESZCpZtXuWmYjFRMV+dw==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.2"
@@ -3539,23 +3724,8 @@
         "@supabase/supabase-js": "^2.76.1"
       }
     },
-    "node_modules/@supabase/ssr/node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/@supabase/storage-js": {
-      "version": "2.97.0",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.97.0.tgz",
-      "integrity": "sha512-9f6NniSBfuMxOWKwEFb+RjJzkfMdJUwv9oHuFJKfe/5VJR8cd90qw68m6Hn0ImGtwG37TUO+QHtoOechxRJ1Yg==",
+      "version": "2.103.3",
       "license": "MIT",
       "dependencies": {
         "iceberg-js": "^0.8.1",
@@ -3566,16 +3736,15 @@
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.97.0",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.97.0.tgz",
-      "integrity": "sha512-kTD91rZNO4LvRUHv4x3/4hNmsEd2ofkYhuba2VMUPRVef1RCmnHtm7rIws38Fg0yQnOSZOplQzafn0GSiy6GVg==",
+      "version": "2.103.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@supabase/auth-js": "2.97.0",
-        "@supabase/functions-js": "2.97.0",
-        "@supabase/postgrest-js": "2.97.0",
-        "@supabase/realtime-js": "2.97.0",
-        "@supabase/storage-js": "2.97.0"
+        "@supabase/auth-js": "2.103.3",
+        "@supabase/functions-js": "2.103.3",
+        "@supabase/postgrest-js": "2.103.3",
+        "@supabase/realtime-js": "2.103.3",
+        "@supabase/storage-js": "2.103.3"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -3583,57 +3752,51 @@
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
       }
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.1.tgz",
-      "integrity": "sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg==",
+      "version": "4.2.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
         "enhanced-resolve": "^5.19.0",
         "jiti": "^2.6.1",
-        "lightningcss": "1.31.1",
+        "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.2.1"
+        "tailwindcss": "4.2.2"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.1.tgz",
-      "integrity": "sha512-yv9jeEFWnjKCI6/T3Oq50yQEOqmpmpfzG1hcZsAOaXFQPfzWprWrlHSdGPEF3WQTi8zu8ohC9Mh9J470nT5pUw==",
+      "version": "4.2.2",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.2.1",
-        "@tailwindcss/oxide-darwin-arm64": "4.2.1",
-        "@tailwindcss/oxide-darwin-x64": "4.2.1",
-        "@tailwindcss/oxide-freebsd-x64": "4.2.1",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.1",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.1",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.2.1",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.2.1",
-        "@tailwindcss/oxide-linux-x64-musl": "4.2.1",
-        "@tailwindcss/oxide-wasm32-wasi": "4.2.1",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.1",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.2.1"
+        "@tailwindcss/oxide-android-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-x64": "4.2.2",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.2",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.2",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.2",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.2"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.1.tgz",
-      "integrity": "sha512-eZ7G1Zm5EC8OOKaesIKuw77jw++QJ2lL9N+dDpdQiAB/c/B2wDh0QPFHbkBVrXnwNugvrbJFk1gK2SsVjwWReg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
+      "integrity": "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==",
       "cpu": [
         "arm64"
       ],
@@ -3648,9 +3811,7 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.1.tgz",
-      "integrity": "sha512-q/LHkOstoJ7pI1J0q6djesLzRvQSIfEto148ppAd+BVQK0JYjQIFSK3JgYZJa+Yzi0DDa52ZsQx2rqytBnf8Hw==",
+      "version": "4.2.2",
       "cpu": [
         "arm64"
       ],
@@ -3665,9 +3826,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.1.tgz",
-      "integrity": "sha512-/f/ozlaXGY6QLbpvd/kFTro2l18f7dHKpB+ieXz+Cijl4Mt9AI2rTrpq7V+t04nK+j9XBQHnSMdeQRhbGyt6fw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
+      "integrity": "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==",
       "cpu": [
         "x64"
       ],
@@ -3682,9 +3843,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.1.tgz",
-      "integrity": "sha512-5e/AkgYJT/cpbkys/OU2Ei2jdETCLlifwm7ogMC7/hksI2fC3iiq6OcXwjibcIjPung0kRtR3TxEITkqgn0TcA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
+      "integrity": "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==",
       "cpu": [
         "x64"
       ],
@@ -3699,9 +3860,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.1.tgz",
-      "integrity": "sha512-Uny1EcVTTmerCKt/1ZuKTkb0x8ZaiuYucg2/kImO5A5Y/kBz41/+j0gxUZl+hTF3xkWpDmHX+TaWhOtba2Fyuw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
+      "integrity": "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==",
       "cpu": [
         "arm"
       ],
@@ -3716,9 +3877,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.1.tgz",
-      "integrity": "sha512-CTrwomI+c7n6aSSQlsPL0roRiNMDQ/YzMD9EjcR+H4f0I1SQ8QqIuPnsVp7QgMkC1Qi8rtkekLkOFjo7OlEFRQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
+      "integrity": "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==",
       "cpu": [
         "arm64"
       ],
@@ -3733,9 +3894,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.1.tgz",
-      "integrity": "sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
+      "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
       "cpu": [
         "arm64"
       ],
@@ -3750,9 +3911,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.1.tgz",
-      "integrity": "sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
+      "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
       "cpu": [
         "x64"
       ],
@@ -3767,9 +3928,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.1.tgz",
-      "integrity": "sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
+      "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
       "cpu": [
         "x64"
       ],
@@ -3784,9 +3945,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.1.tgz",
-      "integrity": "sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
+      "integrity": "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -3814,9 +3975,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.1.tgz",
-      "integrity": "sha512-YlUEHRHBGnCMh4Nj4GnqQyBtsshUPdiNroZj8VPkvTZSoHsilRCwXcVKnG9kyi0ZFAS/3u+qKHBdDc81SADTRA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
+      "integrity": "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==",
       "cpu": [
         "arm64"
       ],
@@ -3831,9 +3992,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.1.tgz",
-      "integrity": "sha512-rbO34G5sMWWyrN/idLeVxAZgAKWrn5LiR3/I90Q9MkA67s6T1oB0xtTe+0heoBvHSpbU9Mk7i6uwJnpo4u21XQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
+      "integrity": "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==",
       "cpu": [
         "x64"
       ],
@@ -3848,23 +4009,99 @@
       }
     },
     "node_modules/@tailwindcss/postcss": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.1.tgz",
-      "integrity": "sha512-OEwGIBnXnj7zJeonOh6ZG9woofIjGrd2BORfvE5p9USYKDCZoQmfqLcfNiRWoJlRWLdNPn2IgVZuWAOM4iTYMw==",
+      "version": "4.2.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.2.1",
-        "@tailwindcss/oxide": "4.2.1",
+        "@tailwindcss/node": "4.2.2",
+        "@tailwindcss/oxide": "4.2.2",
         "postcss": "^8.5.6",
-        "tailwindcss": "4.2.1"
+        "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@ts-morph/common": {
       "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.27.0.tgz",
-      "integrity": "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3875,8 +4112,6 @@
     },
     "node_modules/@ts-morph/common/node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3884,9 +4119,7 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.5",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3898,8 +4131,6 @@
     },
     "node_modules/@ts-morph/common/node_modules/fast-glob": {
       "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3915,8 +4146,6 @@
     },
     "node_modules/@ts-morph/common/node_modules/glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3927,13 +4156,11 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.5",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -3944,8 +4171,6 @@
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -3953,100 +4178,103 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.33",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
-      "integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
+      "version": "20.19.39",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/phoenix": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
-      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==",
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
       "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
       "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/set-cookie-parser": {
+      "version": "2.4.10",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/statuses": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
-      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/validate-npm-package-name": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/validate-npm-package-name/-/validate-npm-package-name-4.0.2.tgz",
-      "integrity": "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.1.tgz",
-      "integrity": "sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==",
+      "version": "8.58.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.56.1",
-        "@typescript-eslint/type-utils": "8.56.1",
-        "@typescript-eslint/utils": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1",
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/type-utils": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4056,15 +4284,13 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.56.1",
+        "@typescript-eslint/parser": "^8.58.2",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
       "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4072,16 +4298,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
-      "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
+      "version": "8.58.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.56.1",
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1",
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4093,18 +4318,16 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
-      "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
+      "version": "8.58.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.56.1",
-        "@typescript-eslint/types": "^8.56.1",
+        "@typescript-eslint/tsconfig-utils": "^8.58.2",
+        "@typescript-eslint/types": "^8.58.2",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4115,18 +4338,16 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
-      "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
+      "version": "8.58.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1"
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4137,9 +4358,7 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
-      "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
+      "version": "8.58.2",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4150,21 +4369,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.1.tgz",
-      "integrity": "sha512-yB/7dxi7MgTtGhZdaHCemf7PuwrHMenHjmzgUW1aJpO+bBU43OycnM3Wn+DdvDO/8zzA9HlhaJ0AUGuvri4oGg==",
+      "version": "8.58.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1",
-        "@typescript-eslint/utils": "8.56.1",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2",
         "debug": "^4.4.3",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4175,13 +4392,11 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
-      "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
+      "version": "8.58.2",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4193,21 +4408,19 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
-      "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
+      "version": "8.58.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.56.1",
-        "@typescript-eslint/tsconfig-utils": "8.56.1",
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1",
+        "@typescript-eslint/project-service": "8.58.2",
+        "@typescript-eslint/tsconfig-utils": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/visitor-keys": "8.58.2",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4217,13 +4430,11 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4231,9 +4442,7 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.5",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4244,13 +4453,11 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.5",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -4261,8 +4468,6 @@
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
       "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4273,16 +4478,14 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
-      "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
+      "version": "8.58.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.56.1",
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1"
+        "@typescript-eslint/scope-manager": "8.58.2",
+        "@typescript-eslint/types": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4293,17 +4496,15 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
-      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+      "version": "8.58.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/types": "8.58.2",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -4316,8 +4517,6 @@
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -4357,8 +4556,6 @@
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
-      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
       "cpu": [
         "arm64"
       ],
@@ -4554,6 +4751,19 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
@@ -4596,10 +4806,131 @@
         "win32"
       ]
     },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "6.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "1.0.0-rc.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4612,10 +4943,9 @@
     },
     "node_modules/acorn": {
       "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4625,8 +4955,6 @@
     },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -4635,8 +4963,6 @@
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4645,8 +4971,6 @@
     },
     "node_modules/ajv": {
       "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4662,8 +4986,6 @@
     },
     "node_modules/ajv-formats": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4680,8 +5002,6 @@
     },
     "node_modules/ajv-formats/node_modules/ajv": {
       "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4697,28 +5017,19 @@
     },
     "node_modules/ajv-formats/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "version": "5.0.1",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4733,8 +5044,6 @@
     },
     "node_modules/ansis": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.2.0.tgz",
-      "integrity": "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -4743,15 +5052,11 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
-      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
@@ -4761,19 +5066,15 @@
       }
     },
     "node_modules/aria-query": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
-      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "version": "5.3.0",
       "dev": true,
       "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 0.4"
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
-      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4789,8 +5090,6 @@
     },
     "node_modules/array-includes": {
       "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
-      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4812,8 +5111,6 @@
     },
     "node_modules/array.prototype.findlast": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
-      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4833,8 +5130,6 @@
     },
     "node_modules/array.prototype.findlastindex": {
       "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
-      "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4855,8 +5150,6 @@
     },
     "node_modules/array.prototype.flat": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
-      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4874,8 +5167,6 @@
     },
     "node_modules/array.prototype.flatmap": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
-      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4893,8 +5184,6 @@
     },
     "node_modules/array.prototype.tosorted": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
-      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4910,8 +5199,6 @@
     },
     "node_modules/arraybuffer.prototype.slice": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
-      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4930,10 +5217,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
-      "integrity": "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4945,15 +5238,11 @@
     },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
-      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/async-function": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
-      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4962,8 +5251,6 @@
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4977,9 +5264,7 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
-      "integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
+      "version": "4.11.3",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -4988,8 +5273,6 @@
     },
     "node_modules/axobject-query": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
-      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -4998,15 +5281,11 @@
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "version": "2.10.19",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -5015,10 +5294,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/body-parser": {
       "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5041,9 +5326,7 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5053,8 +5336,6 @@
     },
     "node_modules/braces": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5065,9 +5346,7 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
       "dev": true,
       "funding": [
         {
@@ -5084,12 +5363,13 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -5100,8 +5380,6 @@
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
-      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5116,8 +5394,6 @@
     },
     "node_modules/bytes": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5125,15 +5401,13 @@
       }
     },
     "node_modules/call-bind": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
-      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+      "version": "1.0.9",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
         "set-function-length": "^1.2.2"
       },
       "engines": {
@@ -5145,8 +5419,6 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5159,8 +5431,6 @@
     },
     "node_modules/call-bound": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5176,8 +5446,6 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5185,9 +5453,7 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001774",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001774.tgz",
-      "integrity": "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==",
+      "version": "1.0.30001788",
       "funding": [
         {
           "type": "opencollective",
@@ -5204,10 +5470,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5223,8 +5495,6 @@
     },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
-      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
       "license": "Apache-2.0",
       "dependencies": {
         "clsx": "^2.1.1"
@@ -5235,8 +5505,6 @@
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
-      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5251,8 +5519,6 @@
     },
     "node_modules/cli-spinners": {
       "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5264,8 +5530,6 @@
     },
     "node_modules/cli-width": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
-      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -5274,14 +5538,10 @@
     },
     "node_modules/client-only": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
-      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5293,27 +5553,13 @@
         "node": ">=12"
       }
     },
-    "node_modules/cliui/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/cliui/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5327,8 +5573,6 @@
     },
     "node_modules/cliui/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5338,28 +5582,8 @@
         "node": ">=8"
       }
     },
-    "node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/clsx": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5367,15 +5591,11 @@
     },
     "node_modules/code-block-writer": {
       "version": "13.0.3",
-      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
-      "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5387,15 +5607,11 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
       "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5404,15 +5620,11 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "1.1.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5425,8 +5637,6 @@
     },
     "node_modules/content-type": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5435,25 +5645,22 @@
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-      "dev": true,
+      "version": "1.1.1",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5462,8 +5669,6 @@
     },
     "node_modules/cors": {
       "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
-      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5479,9 +5684,7 @@
       }
     },
     "node_modules/cosmiconfig": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+      "version": "9.0.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5507,8 +5710,6 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5520,10 +5721,25 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5535,32 +5751,36 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
-      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
-      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5577,8 +5797,6 @@
     },
     "node_modules/data-view-byte-length": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
-      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5595,8 +5813,6 @@
     },
     "node_modules/data-view-byte-offset": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
-      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5613,8 +5829,6 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5629,10 +5843,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dedent": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
-      "integrity": "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==",
+      "version": "1.7.2",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -5646,15 +5863,11 @@
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
-      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5663,8 +5876,6 @@
     },
     "node_modules/default-browser": {
       "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
-      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5680,8 +5891,6 @@
     },
     "node_modules/default-browser-id": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
-      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5693,8 +5902,6 @@
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5711,8 +5918,6 @@
     },
     "node_modules/define-lazy-prop": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5724,8 +5929,6 @@
     },
     "node_modules/define-properties": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5742,18 +5945,22 @@
     },
     "node_modules/depd": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
@@ -5762,14 +5969,10 @@
     },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
-      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
     },
     "node_modules/diff": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
-      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
+      "version": "8.0.4",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -5778,8 +5981,6 @@
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5789,10 +5990,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dotenv": {
-      "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
-      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "version": "17.4.2",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -5804,8 +6008,6 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5818,9 +6020,7 @@
       }
     },
     "node_modules/eciesjs": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.17.tgz",
-      "integrity": "sha512-TOOURki4G7sD1wDCjj7NfLaXZZ49dFOeEb5y39IXpb8p0hRzVvfvzZHOi5JcT+PpyAbi/Y+lxPb8eTag2WYH8w==",
+      "version": "0.4.18",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5837,29 +6037,21 @@
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.302",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
-      "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
+      "version": "1.5.339",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5867,9 +6059,7 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
-      "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
+      "version": "5.20.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5880,10 +6070,19 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/env-paths": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5892,8 +6091,6 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
-      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5901,9 +6098,7 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
-      "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
+      "version": "1.24.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5971,8 +6166,6 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5981,8 +6174,6 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5990,16 +6181,14 @@
       }
     },
     "node_modules/es-iterator-helpers": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.2.tgz",
-      "integrity": "sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==",
+      "version": "1.3.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
+        "call-bind": "^1.0.9",
         "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.24.1",
+        "es-abstract": "^1.24.2",
         "es-errors": "^1.3.0",
         "es-set-tostringtag": "^2.1.0",
         "function-bind": "^1.1.2",
@@ -6011,16 +6200,19 @@
         "has-symbols": "^1.1.0",
         "internal-slot": "^1.1.0",
         "iterator.prototype": "^1.1.5",
-        "safe-array-concat": "^1.1.3"
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6032,8 +6224,6 @@
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6048,8 +6238,6 @@
     },
     "node_modules/es-shim-unscopables": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
-      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6061,8 +6249,6 @@
     },
     "node_modules/es-to-primitive": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
-      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6079,8 +6265,6 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6089,15 +6273,11 @@
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6108,25 +6288,24 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.3",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.3.tgz",
-      "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
+      "version": "9.39.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-array": "^0.21.2",
         "@eslint/config-helpers": "^0.4.2",
         "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.39.3",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
         "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
@@ -6145,7 +6324,7 @@
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -6169,8 +6348,6 @@
     },
     "node_modules/eslint-config-next": {
       "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.1.6.tgz",
-      "integrity": "sha512-vKq40io2B0XtkkNDYyleATwblNt8xuh3FWp8SpSz3pt7P01OkBFlKsJZ2mWt5WsCySlDQLckb1zMY9yE9Qy0LA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6196,8 +6373,6 @@
     },
     "node_modules/eslint-config-next/node_modules/globals": {
       "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz",
-      "integrity": "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6208,21 +6383,17 @@
       }
     },
     "node_modules/eslint-import-resolver-node": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
-      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+      "version": "0.3.10",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^3.2.7",
-        "is-core-module": "^2.13.0",
-        "resolve": "^1.22.4"
+        "is-core-module": "^2.16.1",
+        "resolve": "^2.0.0-next.6"
       }
     },
     "node_modules/eslint-import-resolver-node/node_modules/debug": {
       "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6231,8 +6402,6 @@
     },
     "node_modules/eslint-import-resolver-typescript": {
       "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.10.1.tgz",
-      "integrity": "sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -6266,8 +6435,6 @@
     },
     "node_modules/eslint-module-utils": {
       "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.12.1.tgz",
-      "integrity": "sha512-L8jSWTze7K2mTg0vos/RuLRS5soomksDPoJLXIslC7c8Wmut3bx7CPpJijDcBZtxQ5lrbUdM+s0OlNbz0DCDNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6284,8 +6451,6 @@
     },
     "node_modules/eslint-module-utils/node_modules/debug": {
       "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6294,10 +6459,9 @@
     },
     "node_modules/eslint-plugin-import": {
       "version": "2.32.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
-      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6328,8 +6492,6 @@
     },
     "node_modules/eslint-plugin-import/node_modules/debug": {
       "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6338,8 +6500,6 @@
     },
     "node_modules/eslint-plugin-jsx-a11y": {
       "version": "6.10.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
-      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6366,10 +6526,16 @@
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
       }
     },
+    "node_modules/eslint-plugin-jsx-a11y/node_modules/aria-query": {
+      "version": "5.3.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/eslint-plugin-react": {
       "version": "7.37.5",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
-      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6400,9 +6566,7 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
-      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+      "version": "7.1.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6416,37 +6580,11 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
-      }
-    },
-    "node_modules/eslint-plugin-react/node_modules/resolve": {
-      "version": "2.0.0-next.6",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
-      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
-        "node-exports-info": "^1.6.0",
-        "object-keys": "^1.1.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -6462,8 +6600,6 @@
     },
     "node_modules/eslint-visitor-keys": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -6475,8 +6611,6 @@
     },
     "node_modules/espree": {
       "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -6493,8 +6627,6 @@
     },
     "node_modules/esprima": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
@@ -6507,8 +6639,6 @@
     },
     "node_modules/esquery": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
-      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -6520,8 +6650,6 @@
     },
     "node_modules/esrecurse": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -6533,18 +6661,22 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -6553,8 +6685,6 @@
     },
     "node_modules/etag": {
       "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6563,8 +6693,6 @@
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
-      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6576,8 +6704,6 @@
     },
     "node_modules/eventsource-parser": {
       "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6586,8 +6712,6 @@
     },
     "node_modules/execa": {
       "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
-      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6611,10 +6735,16 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/express": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
-      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6656,13 +6786,11 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
-      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "version": "8.3.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "10.1.0"
       },
       "engines": {
         "node": ">= 16"
@@ -6674,17 +6802,21 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
-      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6700,8 +6832,6 @@
     },
     "node_modules/fast-glob/node_modules/glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -6713,22 +6843,29 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-string-truncated-width": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-string-width": {
+      "version": "3.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-truncated-width": "^3.0.2"
+      }
+    },
     "node_modules/fast-uri": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
       "dev": true,
       "funding": [
         {
@@ -6742,10 +6879,16 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fast-wrap-ansi": {
+      "version": "0.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-string-width": "^3.0.2"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
-      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -6754,8 +6897,6 @@
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
       "dev": true,
       "funding": [
         {
@@ -6778,8 +6919,6 @@
     },
     "node_modules/figures": {
       "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
-      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6794,8 +6933,6 @@
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
-      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6807,8 +6944,6 @@
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6820,8 +6955,6 @@
     },
     "node_modules/finalhandler": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
-      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6842,8 +6975,6 @@
     },
     "node_modules/find-up": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6859,8 +6990,6 @@
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
-      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6872,16 +7001,12 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/for-each": {
       "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
-      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6896,8 +7021,6 @@
     },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6909,8 +7032,6 @@
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6919,8 +7040,6 @@
     },
     "node_modules/fresh": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6928,9 +7047,7 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.3.3",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
-      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
+      "version": "11.3.4",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6942,10 +7059,20 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -6954,8 +7081,6 @@
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
-      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6975,8 +7100,6 @@
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -6985,22 +7108,16 @@
     },
     "node_modules/fuzzysort": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fuzzysort/-/fuzzysort-3.1.0.tgz",
-      "integrity": "sha512-sR9BNCjBg6LNgwvxlBd0sBABvQitkLzoVY9MYYROQVX/FvfJ4Mai9LsGhDgd8qYdds0bY77VzYd5iuB+v5rwQQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fzf": {
       "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fzf/-/fzf-0.5.2.tgz",
-      "integrity": "sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/generator-function": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
-      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7009,8 +7126,6 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7019,8 +7134,6 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -7029,8 +7142,6 @@
     },
     "node_modules/get-east-asian-width": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7042,8 +7153,6 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7067,8 +7176,6 @@
     },
     "node_modules/get-nonce": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
-      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7076,8 +7183,6 @@
     },
     "node_modules/get-own-enumerable-keys": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/get-own-enumerable-keys/-/get-own-enumerable-keys-1.0.0.tgz",
-      "integrity": "sha512-PKsK2FSrQCyxcGHsGrLDcK0lx+0Ke+6e8KFFozA9/fIQLhQzPaRvJFdcz7+Axg3jUH/Mq+NI4xa5u/UT2tQskA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7089,8 +7194,6 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7103,8 +7206,6 @@
     },
     "node_modules/get-stream": {
       "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7120,8 +7221,6 @@
     },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
-      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7137,9 +7236,7 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.13.6",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
-      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "version": "4.14.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7151,8 +7248,6 @@
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -7164,8 +7259,6 @@
     },
     "node_modules/globals": {
       "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7177,8 +7270,6 @@
     },
     "node_modules/globalthis": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
-      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7194,8 +7285,6 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7207,15 +7296,11 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/graphql": {
-      "version": "16.13.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.0.tgz",
-      "integrity": "sha512-uSisMYERbaB9bkA9M4/4dnqyktaEkf1kMHNKq/7DHyxVeWqHQ2mBmVqm5u6/FVHwF3iCNalKcg82Zfl+tffWoA==",
+      "version": "16.13.2",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7224,8 +7309,6 @@
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
-      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7237,8 +7320,6 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7247,8 +7328,6 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7260,8 +7339,6 @@
     },
     "node_modules/has-proto": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
-      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7276,8 +7353,6 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7289,8 +7364,6 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7305,8 +7378,6 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7317,23 +7388,21 @@
       }
     },
     "node_modules/headers-polyfill": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
-      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+      "version": "5.0.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "@types/set-cookie-parser": "^2.4.10",
+        "set-cookie-parser": "^3.0.1"
+      }
     },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
-      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/hermes-parser": {
       "version": "0.25.1",
-      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
-      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7341,19 +7410,27 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.2",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.2.tgz",
-      "integrity": "sha512-gJnaDHXKDayjt8ue0n8Gs0A007yKXj4Xzb8+cNjZeYsSzzwKc0Lr+OZgYwVfB0pHfUs17EPoLvrOsEaJ9mj+Tg==",
+      "version": "4.12.14",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7373,8 +7450,6 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7387,8 +7462,6 @@
     },
     "node_modules/human-signals": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
-      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -7397,8 +7470,6 @@
     },
     "node_modules/iceberg-js": {
       "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
-      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
@@ -7406,8 +7477,6 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7423,8 +7492,6 @@
     },
     "node_modules/ignore": {
       "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7433,8 +7500,6 @@
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7450,25 +7515,27 @@
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
-      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7481,9 +7548,7 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
-      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "version": "10.1.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7492,8 +7557,6 @@
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7502,8 +7565,6 @@
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
-      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7520,15 +7581,11 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
-      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7547,8 +7604,6 @@
     },
     "node_modules/is-bigint": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
-      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7563,8 +7618,6 @@
     },
     "node_modules/is-boolean-object": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
-      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7580,8 +7633,6 @@
     },
     "node_modules/is-bun-module": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
-      "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7590,8 +7641,6 @@
     },
     "node_modules/is-bun-module/node_modules/semver": {
       "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -7603,8 +7652,6 @@
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7616,8 +7663,6 @@
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7632,8 +7677,6 @@
     },
     "node_modules/is-data-view": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
-      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7650,8 +7693,6 @@
     },
     "node_modules/is-date-object": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
-      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7667,8 +7708,6 @@
     },
     "node_modules/is-docker": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -7683,8 +7722,6 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7693,8 +7730,6 @@
     },
     "node_modules/is-finalizationregistry": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
-      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7709,8 +7744,6 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7719,8 +7752,6 @@
     },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
-      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7739,8 +7770,6 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7752,8 +7781,6 @@
     },
     "node_modules/is-in-ssh": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
-      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7765,8 +7792,6 @@
     },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
-      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7784,8 +7809,6 @@
     },
     "node_modules/is-interactive": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
-      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7797,8 +7820,6 @@
     },
     "node_modules/is-map": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
-      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7810,8 +7831,6 @@
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
-      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7823,15 +7842,11 @@
     },
     "node_modules/is-node-process": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
-      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7840,8 +7855,6 @@
     },
     "node_modules/is-number-object": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
-      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7857,8 +7870,6 @@
     },
     "node_modules/is-obj": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-3.0.0.tgz",
-      "integrity": "sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7870,8 +7881,6 @@
     },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7881,17 +7890,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7909,8 +7919,6 @@
     },
     "node_modules/is-regexp": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-3.1.0.tgz",
-      "integrity": "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7922,8 +7930,6 @@
     },
     "node_modules/is-set": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
-      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7935,8 +7941,6 @@
     },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
-      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7951,8 +7955,6 @@
     },
     "node_modules/is-stream": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7964,8 +7966,6 @@
     },
     "node_modules/is-string": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
-      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7981,8 +7981,6 @@
     },
     "node_modules/is-symbol": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
-      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7999,8 +7997,6 @@
     },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
-      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8015,8 +8011,6 @@
     },
     "node_modules/is-unicode-supported": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
-      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8028,8 +8022,6 @@
     },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
-      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8041,8 +8033,6 @@
     },
     "node_modules/is-weakref": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
-      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8057,8 +8047,6 @@
     },
     "node_modules/is-weakset": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
-      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8074,8 +8062,6 @@
     },
     "node_modules/is-wsl": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8090,22 +8076,16 @@
     },
     "node_modules/isarray": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
-      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8122,8 +8102,6 @@
     },
     "node_modules/jiti": {
       "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -8131,9 +8109,7 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "version": "6.2.2",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -8142,15 +8118,11 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8160,10 +8132,55 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
-      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -8175,43 +8192,31 @@
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
-      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/json5": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -8223,8 +8228,6 @@
     },
     "node_modules/jsonfile": {
       "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8236,8 +8239,6 @@
     },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
-      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8252,8 +8253,6 @@
     },
     "node_modules/keyv": {
       "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8262,8 +8261,6 @@
     },
     "node_modules/kleur": {
       "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
-      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8272,15 +8269,11 @@
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
-      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
-      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
       "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/language-tags": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
-      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8292,8 +8285,6 @@
     },
     "node_modules/levn": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8305,9 +8296,7 @@
       }
     },
     "node_modules/lightningcss": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.31.1.tgz",
-      "integrity": "sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==",
+      "version": "1.32.0",
       "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
@@ -8321,23 +8310,23 @@
         "url": "https://opencollective.com/parcel"
       },
       "optionalDependencies": {
-        "lightningcss-android-arm64": "1.31.1",
-        "lightningcss-darwin-arm64": "1.31.1",
-        "lightningcss-darwin-x64": "1.31.1",
-        "lightningcss-freebsd-x64": "1.31.1",
-        "lightningcss-linux-arm-gnueabihf": "1.31.1",
-        "lightningcss-linux-arm64-gnu": "1.31.1",
-        "lightningcss-linux-arm64-musl": "1.31.1",
-        "lightningcss-linux-x64-gnu": "1.31.1",
-        "lightningcss-linux-x64-musl": "1.31.1",
-        "lightningcss-win32-arm64-msvc": "1.31.1",
-        "lightningcss-win32-x64-msvc": "1.31.1"
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
       }
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.31.1.tgz",
-      "integrity": "sha512-HXJF3x8w9nQ4jbXRiNppBCqeZPIAfUo8zE/kOEGbW5NZvGc/K7nMxbhIr+YlFlHW5mpbg/YFPdbnCh1wAXCKFg==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "cpu": [
         "arm64"
       ],
@@ -8356,9 +8345,7 @@
       }
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.31.1.tgz",
-      "integrity": "sha512-02uTEqf3vIfNMq3h/z2cJfcOXnQ0GRwQrkmPafhueLb2h7mqEidiCzkE4gBMEH65abHRiQvhdcQ+aP0D0g67sg==",
+      "version": "1.32.0",
       "cpu": [
         "arm64"
       ],
@@ -8377,9 +8364,9 @@
       }
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.31.1.tgz",
-      "integrity": "sha512-1ObhyoCY+tGxtsz1lSx5NXCj3nirk0Y0kB/g8B8DT+sSx4G9djitg9ejFnjb3gJNWo7qXH4DIy2SUHvpoFwfTA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "cpu": [
         "x64"
       ],
@@ -8398,9 +8385,9 @@
       }
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.31.1.tgz",
-      "integrity": "sha512-1RINmQKAItO6ISxYgPwszQE1BrsVU5aB45ho6O42mu96UiZBxEXsuQ7cJW4zs4CEodPUioj/QrXW1r9pLUM74A==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "cpu": [
         "x64"
       ],
@@ -8419,9 +8406,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.31.1.tgz",
-      "integrity": "sha512-OOCm2//MZJ87CdDK62rZIu+aw9gBv4azMJuA8/KB74wmfS3lnC4yoPHm0uXZ/dvNNHmnZnB8XLAZzObeG0nS1g==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
       "cpu": [
         "arm"
       ],
@@ -8440,9 +8427,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.31.1.tgz",
-      "integrity": "sha512-WKyLWztD71rTnou4xAD5kQT+982wvca7E6QoLpoawZ1gP9JM0GJj4Tp5jMUh9B3AitHbRZ2/H3W5xQmdEOUlLg==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "cpu": [
         "arm64"
       ],
@@ -8461,9 +8448,9 @@
       }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.31.1.tgz",
-      "integrity": "sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
       ],
@@ -8482,9 +8469,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.31.1.tgz",
-      "integrity": "sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
       "cpu": [
         "x64"
       ],
@@ -8503,9 +8490,9 @@
       }
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.31.1.tgz",
-      "integrity": "sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
       ],
@@ -8524,9 +8511,9 @@
       }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.31.1.tgz",
-      "integrity": "sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "cpu": [
         "arm64"
       ],
@@ -8545,9 +8532,9 @@
       }
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.31.1",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.31.1.tgz",
-      "integrity": "sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "cpu": [
         "x64"
       ],
@@ -8567,15 +8554,11 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8590,15 +8573,11 @@
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
-      "integrity": "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8614,8 +8593,6 @@
     },
     "node_modules/log-symbols/node_modules/chalk": {
       "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8627,8 +8604,6 @@
     },
     "node_modules/log-symbols/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8640,8 +8615,6 @@
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8653,8 +8626,6 @@
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
-      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -8663,17 +8634,21 @@
     },
     "node_modules/lucide-react": {
       "version": "0.575.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.575.0.tgz",
-      "integrity": "sha512-VuXgKZrk0uiDlWjGGXmKV6MSk9Yy4l10qgVvzGn2AWBx1Ylt0iBexKOAoA6I7JO3m+M9oeovJd3yYENfkUbOeg==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8682,18 +8657,19 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/media-typer": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8702,8 +8678,6 @@
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
-      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8715,15 +8689,11 @@
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8732,8 +8702,6 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8746,8 +8714,6 @@
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8756,8 +8722,6 @@
     },
     "node_modules/mime-types": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8773,8 +8737,6 @@
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8783,8 +8745,6 @@
     },
     "node_modules/mimic-function": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
-      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8794,10 +8754,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.5",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -8809,8 +8775,6 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -8819,35 +8783,31 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/msw": {
-      "version": "2.12.10",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.12.10.tgz",
-      "integrity": "sha512-G3VUymSE0/iegFnuipujpwyTM2GuZAKXNeerUSrG2+Eg391wW63xFs5ixWsK9MWzr1AGoSkYGmyAzNgbR3+urw==",
+      "version": "2.13.4",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@inquirer/confirm": "^5.0.0",
-        "@mswjs/interceptors": "^0.41.2",
-        "@open-draft/deferred-promise": "^2.2.0",
+        "@inquirer/confirm": "^6.0.11",
+        "@mswjs/interceptors": "^0.41.3",
+        "@open-draft/deferred-promise": "^3.0.0",
         "@types/statuses": "^2.0.6",
-        "cookie": "^1.0.2",
-        "graphql": "^16.12.0",
-        "headers-polyfill": "^4.0.2",
+        "cookie": "^1.1.1",
+        "graphql": "^16.13.2",
+        "headers-polyfill": "^5.0.1",
         "is-node-process": "^1.2.0",
         "outvariant": "^1.4.3",
         "path-to-regexp": "^6.3.0",
         "picocolors": "^1.1.1",
-        "rettime": "^0.10.1",
+        "rettime": "^0.11.7",
         "statuses": "^2.0.2",
         "strict-event-emitter": "^0.5.1",
-        "tough-cookie": "^6.0.0",
-        "type-fest": "^5.2.0",
+        "tough-cookie": "^6.0.1",
+        "type-fest": "^5.5.0",
         "until-async": "^3.0.2",
         "yargs": "^17.7.2"
       },
@@ -8869,34 +8829,16 @@
         }
       }
     },
-    "node_modules/msw/node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/mute-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
-      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "version": "3.0.0",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
       "funding": [
         {
           "type": "github",
@@ -8913,8 +8855,6 @@
     },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
-      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -8929,15 +8869,11 @@
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8946,8 +8882,6 @@
     },
     "node_modules/next": {
       "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
-      "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
       "license": "MIT",
       "dependencies": {
         "@next/env": "16.1.6",
@@ -8999,8 +8933,6 @@
     },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -9027,9 +8959,6 @@
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "deprecated": "Use your platform's native DOMException instead",
       "dev": true,
       "funding": [
         {
@@ -9048,8 +8977,6 @@
     },
     "node_modules/node-exports-info": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
-      "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9067,8 +8994,6 @@
     },
     "node_modules/node-fetch": {
       "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9085,16 +9010,12 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.27",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-      "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "version": "2.0.37",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/npm-run-path": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
-      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9110,8 +9031,6 @@
     },
     "node_modules/npm-run-path/node_modules/path-key": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9123,8 +9042,6 @@
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9133,8 +9050,6 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
-      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9146,8 +9061,6 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9156,8 +9069,6 @@
     },
     "node_modules/object-treeify": {
       "version": "1.1.33",
-      "resolved": "https://registry.npmjs.org/object-treeify/-/object-treeify-1.1.33.tgz",
-      "integrity": "sha512-EFVjAYfzWqWsBMRHPMAXLCDIJnpMhdWAqR7xG6M6a2cs6PMFpl/+Z20w9zDW4vkxOFfddegBKq9Rehd0bxWE7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9166,8 +9077,6 @@
     },
     "node_modules/object.assign": {
       "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
-      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9187,8 +9096,6 @@
     },
     "node_modules/object.entries": {
       "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
-      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9203,8 +9110,6 @@
     },
     "node_modules/object.fromentries": {
       "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
-      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9222,8 +9127,6 @@
     },
     "node_modules/object.groupby": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
-      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9237,8 +9140,6 @@
     },
     "node_modules/object.values": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
-      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9254,10 +9155,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9269,8 +9177,6 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -9279,8 +9185,6 @@
     },
     "node_modules/onetime": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
-      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9295,8 +9199,6 @@
     },
     "node_modules/open": {
       "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
-      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9316,8 +9218,6 @@
     },
     "node_modules/optionator": {
       "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
-      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9334,8 +9234,6 @@
     },
     "node_modules/ora": {
       "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-8.2.0.tgz",
-      "integrity": "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9358,8 +9256,6 @@
     },
     "node_modules/ora/node_modules/chalk": {
       "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9371,15 +9267,11 @@
     },
     "node_modules/outvariant": {
       "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
-      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/own-keys": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
-      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9396,8 +9288,6 @@
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9412,8 +9302,6 @@
     },
     "node_modules/p-locate": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9428,15 +9316,11 @@
     },
     "node_modules/package-manager-detector": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
-      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9448,8 +9332,6 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9467,8 +9349,6 @@
     },
     "node_modules/parse-ms": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
-      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9478,10 +9358,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9490,15 +9379,11 @@
     },
     "node_modules/path-browserify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9507,8 +9392,6 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9517,28 +9400,25 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
-      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9550,8 +9430,6 @@
     },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
-      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9560,8 +9438,6 @@
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
-      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9569,9 +9445,7 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.10",
       "dev": true,
       "funding": [
         {
@@ -9599,8 +9473,6 @@
     },
     "node_modules/postcss-selector-parser": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-      "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9613,8 +9485,6 @@
     },
     "node_modules/powershell-utils": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
-      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9626,18 +9496,38 @@
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
-      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9652,8 +9542,6 @@
     },
     "node_modules/prompts": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
-      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9666,8 +9554,6 @@
     },
     "node_modules/prompts/node_modules/kleur": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9676,8 +9562,6 @@
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9686,10 +9570,13 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9702,8 +9589,6 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9711,9 +9596,7 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.1",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -9728,8 +9611,6 @@
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true,
       "funding": [
         {
@@ -9749,8 +9630,6 @@
     },
     "node_modules/radix-ui": {
       "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.4.3.tgz",
-      "integrity": "sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.3",
@@ -9826,8 +9705,6 @@
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9836,8 +9713,6 @@
     },
     "node_modules/raw-body": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
-      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9852,18 +9727,16 @@
     },
     "node_modules/react": {
       "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
-      "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
       "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9872,16 +9745,12 @@
       }
     },
     "node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "version": "17.0.2",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
-      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
       "license": "MIT",
       "dependencies": {
         "react-remove-scroll-bar": "^2.3.7",
@@ -9905,8 +9774,6 @@
     },
     "node_modules/react-remove-scroll-bar": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
-      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
       "license": "MIT",
       "dependencies": {
         "react-style-singleton": "^2.2.2",
@@ -9927,8 +9794,6 @@
     },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
-      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
       "license": "MIT",
       "dependencies": {
         "get-nonce": "^1.0.0",
@@ -9949,8 +9814,6 @@
     },
     "node_modules/recast": {
       "version": "0.23.11",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
-      "integrity": "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9964,10 +9827,20 @@
         "node": ">= 4"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
-      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9989,8 +9862,6 @@
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
-      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10010,8 +9881,6 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10020,8 +9889,6 @@
     },
     "node_modules/require-from-string": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10029,13 +9896,14 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "version": "2.0.0-next.6",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "es-errors": "^1.3.0",
         "is-core-module": "^2.16.1",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -10051,8 +9919,6 @@
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10061,8 +9927,6 @@
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -10071,8 +9935,6 @@
     },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
-      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10087,16 +9949,12 @@
       }
     },
     "node_modules/rettime": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.10.1.tgz",
-      "integrity": "sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==",
+      "version": "0.11.7",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10104,10 +9962,45 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.15",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.124.0",
+        "@rolldown/pluginutils": "1.0.0-rc.15"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.15",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/router": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
-      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10122,9 +10015,7 @@
       }
     },
     "node_modules/router/node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -10134,8 +10025,6 @@
     },
     "node_modules/run-applescript": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
-      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10147,8 +10036,6 @@
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "dev": true,
       "funding": [
         {
@@ -10171,8 +10058,6 @@
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
-      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10191,8 +10076,6 @@
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
-      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10208,8 +10091,6 @@
     },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
-      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10226,21 +10107,26 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -10249,8 +10135,6 @@
     },
     "node_modules/send": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
-      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10276,8 +10160,6 @@
     },
     "node_modules/serve-static": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
-      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10294,10 +10176,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/set-cookie-parser": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10314,8 +10199,6 @@
     },
     "node_modules/set-function-name": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
-      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10330,8 +10213,6 @@
     },
     "node_modules/set-proto": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
-      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10345,15 +10226,11 @@
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/shadcn": {
       "version": "3.8.5",
-      "resolved": "https://registry.npmjs.org/shadcn/-/shadcn-3.8.5.tgz",
-      "integrity": "sha512-jPRx44e+eyeV7xwY3BLJXcfrks00+M0h5BGB9l6DdcBW4BpAj4x3lVmVy0TXPEs2iHEisxejr62sZAAw6B1EVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10399,8 +10276,6 @@
     },
     "node_modules/shadcn/node_modules/fast-glob": {
       "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10416,8 +10291,6 @@
     },
     "node_modules/shadcn/node_modules/glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -10429,8 +10302,6 @@
     },
     "node_modules/shadcn/node_modules/tsconfig-paths": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
-      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10444,8 +10315,6 @@
     },
     "node_modules/shadcn/node_modules/zod": {
       "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -10454,8 +10323,6 @@
     },
     "node_modules/sharp": {
       "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -10499,8 +10366,6 @@
     },
     "node_modules/sharp/node_modules/semver": {
       "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -10512,8 +10377,6 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10525,8 +10388,6 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10535,8 +10396,6 @@
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10554,14 +10413,12 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -10572,8 +10429,6 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
-      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10591,8 +10446,6 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
-      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10609,10 +10462,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -10624,15 +10480,11 @@
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -10641,8 +10493,6 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -10650,25 +10500,29 @@
     },
     "node_modules/stable-hash": {
       "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
-      "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
-      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.2.2.tgz",
-      "integrity": "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10680,8 +10534,6 @@
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
-      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10694,15 +10546,11 @@
     },
     "node_modules/strict-event-emitter": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
-      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10719,15 +10567,11 @@
     },
     "node_modules/string-width/node_modules/emoji-regex": {
       "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
-      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10741,8 +10585,6 @@
     },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
-      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10769,8 +10611,6 @@
     },
     "node_modules/string.prototype.repeat": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
-      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10780,8 +10620,6 @@
     },
     "node_modules/string.prototype.trim": {
       "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
-      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10802,8 +10640,6 @@
     },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
-      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10821,8 +10657,6 @@
     },
     "node_modules/string.prototype.trimstart": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
-      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10839,8 +10673,6 @@
     },
     "node_modules/stringify-object": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-5.0.0.tgz",
-      "integrity": "sha512-zaJYxz2FtcMb4f+g60KsRNFOpVMUyuJgA51Zi5Z1DOTC3S59+OQiVOzE9GZt0x72uBGWKsQIuBKeF9iusmKFsg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -10856,13 +10688,11 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -10871,10 +10701,19 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
     "node_modules/strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10883,8 +10722,6 @@
     },
     "node_modules/strip-final-newline": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
-      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10894,10 +10731,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10909,8 +10755,6 @@
     },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
-      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
       "license": "MIT",
       "dependencies": {
         "client-only": "0.0.1"
@@ -10932,8 +10776,6 @@
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10945,8 +10787,6 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10956,10 +10796,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
-      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10971,8 +10814,6 @@
     },
     "node_modules/tailwind-merge": {
       "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
-      "integrity": "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -10980,16 +10821,12 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
-      "integrity": "sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==",
+      "version": "4.2.2",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+      "version": "2.3.2",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11002,15 +10839,16 @@
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "version": "1.1.1",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11018,14 +10856,12 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -11036,8 +10872,6 @@
     },
     "node_modules/tinyglobby/node_modules/fdir": {
       "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11053,11 +10887,10 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11065,30 +10898,32 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/tldts": {
-      "version": "7.0.23",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.23.tgz",
-      "integrity": "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==",
+      "version": "7.0.28",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.23"
+        "tldts-core": "^7.0.28"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.23",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
-      "integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
+      "version": "7.0.28",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11100,8 +10935,6 @@
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11109,9 +10942,7 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
-      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "version": "6.0.1",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -11121,10 +10952,19 @@
         "node": ">=16"
       }
     },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/ts-api-utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
-      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "version": "2.5.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11136,8 +10976,6 @@
     },
     "node_modules/ts-morph": {
       "version": "26.0.0",
-      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-26.0.0.tgz",
-      "integrity": "sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11147,8 +10985,6 @@
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
-      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11160,8 +10996,6 @@
     },
     "node_modules/tsconfig-paths/node_modules/json5": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11173,14 +11007,10 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
     "node_modules/tw-animate-css": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
-      "integrity": "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -11189,8 +11019,6 @@
     },
     "node_modules/type-check": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11201,9 +11029,7 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.4.tgz",
-      "integrity": "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==",
+      "version": "5.5.0",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
@@ -11218,8 +11044,6 @@
     },
     "node_modules/type-is": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11233,8 +11057,6 @@
     },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
-      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11248,8 +11070,6 @@
     },
     "node_modules/typed-array-byte-length": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
-      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11268,8 +11088,6 @@
     },
     "node_modules/typed-array-byte-offset": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
-      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11290,8 +11108,6 @@
     },
     "node_modules/typed-array-length": {
       "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
-      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11311,10 +11127,9 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11324,16 +11139,14 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.56.1.tgz",
-      "integrity": "sha512-U4lM6pjmBX7J5wk4szltF7I1cGBHXZopnAXCMXb3+fZ3B/0Z3hq3wS/CCUB2NZBNAExK92mCU2tEohWuwVMsDQ==",
+      "version": "8.58.2",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.56.1",
-        "@typescript-eslint/parser": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1",
-        "@typescript-eslint/utils": "8.56.1"
+        "@typescript-eslint/eslint-plugin": "8.58.2",
+        "@typescript-eslint/parser": "8.58.2",
+        "@typescript-eslint/typescript-estree": "8.58.2",
+        "@typescript-eslint/utils": "8.58.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -11344,13 +11157,11 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
-      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11366,16 +11177,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
-      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11387,8 +11202,6 @@
     },
     "node_modules/universalify": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11397,8 +11210,6 @@
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11407,8 +11218,6 @@
     },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
-      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -11442,8 +11251,6 @@
     },
     "node_modules/until-async": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
-      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -11452,8 +11259,6 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
       "dev": true,
       "funding": [
         {
@@ -11483,8 +11288,6 @@
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -11493,8 +11296,6 @@
     },
     "node_modules/use-callback-ref": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
-      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
@@ -11514,8 +11315,6 @@
     },
     "node_modules/use-sidecar": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
-      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
       "license": "MIT",
       "dependencies": {
         "detect-node-es": "^1.1.0",
@@ -11536,8 +11335,6 @@
     },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
-      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -11545,15 +11342,11 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/validate-npm-package-name": {
       "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-7.0.2.tgz",
-      "integrity": "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -11562,28 +11355,249 @@
     },
     "node_modules/vary": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.8",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.15",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -11598,8 +11612,6 @@
     },
     "node_modules/which-boxed-primitive": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
-      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11618,8 +11630,6 @@
     },
     "node_modules/which-builtin-type": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
-      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11646,8 +11656,6 @@
     },
     "node_modules/which-collection": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
-      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11665,8 +11673,6 @@
     },
     "node_modules/which-typed-array": {
       "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
-      "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11685,10 +11691,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
-      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11696,9 +11715,7 @@
       }
     },
     "node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "version": "7.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11707,30 +11724,19 @@
         "strip-ansi": "^6.0.0"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/wrap-ansi/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11744,8 +11750,6 @@
     },
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11757,15 +11761,11 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.0",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -11785,8 +11785,6 @@
     },
     "node_modules/wsl-utils": {
       "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
-      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11800,10 +11798,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -11812,15 +11821,11 @@
     },
     "node_modules/yallist": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11838,35 +11843,19 @@
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
       }
     },
-    "node_modules/yargs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/yargs/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11880,8 +11869,6 @@
     },
     "node_modules/yargs/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11893,8 +11880,6 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11904,23 +11889,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/yoctocolors": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
-      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+    "node_modules/yocto-spinner": {
+      "version": "1.1.0",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "yoctocolors": "^2.1.1"
+      },
       "engines": {
-        "node": ">=18"
+        "node": ">=18.19"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/yoctocolors-cjs": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
-      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11932,28 +11916,23 @@
     },
     "node_modules/zod": {
       "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "version": "3.25.2",
       "dev": true,
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.25 || ^4"
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zod-validation-error": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
-      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@supabase/ssr": "^0.8.0",
@@ -22,14 +24,20 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@vitejs/plugin-react": "^6.0.1",
     "eslint": "^9",
     "eslint-config-next": "16.1.6",
+    "jsdom": "^29.0.2",
     "shadcn": "^3.8.5",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.4"
   }
 }

--- a/frontend/src/app/(app)/dashboard/__tests__/attendee-dashboard.test.tsx
+++ b/frontend/src/app/(app)/dashboard/__tests__/attendee-dashboard.test.tsx
@@ -1,0 +1,206 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createRef } from "react";
+import { AttendeeContent, AttendeeControls } from "../attendee-dashboard";
+import type { AttendeeEventItem } from "../attendee-dashboard";
+
+const MOCK_EVENT = {
+  event_id: "evt-1",
+  created_by: "org-1",
+  name: "Tech Meetup",
+  starts_at: new Date(Date.now() - 3600000).toISOString(),
+  ends_at: new Date(Date.now() + 86400000).toISOString(),
+  location: "Room 101",
+  description: "A tech meetup",
+  max_participants: 50,
+  is_active: true,
+  indexing_status: "completed" as const,
+  cleanup_status: "pending" as const,
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+const FUTURE_EVENT = {
+  ...MOCK_EVENT,
+  event_id: "evt-2",
+  name: "Future Conference",
+  starts_at: new Date(Date.now() + 86400000).toISOString(),
+};
+
+describe("AttendeeControls", () => {
+  it("renders search input and discover button", () => {
+    render(
+      <AttendeeControls
+        searchText=""
+        onSearchTextChange={vi.fn()}
+        onOpenDiscover={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByPlaceholderText("Search your events")).toBeInTheDocument();
+    expect(screen.getByText("Discover Events")).toBeInTheDocument();
+  });
+
+  it("calls onSearchTextChange when typing", async () => {
+    const onSearchTextChange = vi.fn();
+    render(
+      <AttendeeControls
+        searchText=""
+        onSearchTextChange={onSearchTextChange}
+        onOpenDiscover={vi.fn()}
+      />,
+    );
+
+    await userEvent.type(screen.getByPlaceholderText("Search your events"), "test");
+    expect(onSearchTextChange).toHaveBeenCalled();
+  });
+
+  it("calls onOpenDiscover when button is clicked", async () => {
+    const onOpenDiscover = vi.fn();
+    render(
+      <AttendeeControls
+        searchText=""
+        onSearchTextChange={vi.fn()}
+        onOpenDiscover={onOpenDiscover}
+      />,
+    );
+
+    await userEvent.click(screen.getByText("Discover Events"));
+    expect(onOpenDiscover).toHaveBeenCalledOnce();
+  });
+});
+
+describe("AttendeeContent", () => {
+  const defaultProps = {
+    openEventMenuId: null,
+    openMenuContainerRef: createRef<HTMLDivElement>(),
+    leavingEventId: null,
+    onToggleEventMenu: vi.fn(),
+    onViewEventDetail: vi.fn(),
+    onViewRsvpList: vi.fn(),
+    onEditConsents: vi.fn(),
+    onLeaveEvent: vi.fn(),
+    onStartRecognition: vi.fn(),
+    formatEventDate: (v: string) => new Date(v).toLocaleDateString(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows loading spinner when loading", () => {
+    render(<AttendeeContent {...defaultProps} loading={true} events={[]} />);
+
+    const spinners = document.querySelectorAll(".animate-spin");
+    expect(spinners.length).toBeGreaterThan(0);
+  });
+
+  it("shows empty state when no events", () => {
+    render(<AttendeeContent {...defaultProps} loading={false} events={[]} />);
+
+    expect(screen.getByText("No upcoming events found")).toBeInTheDocument();
+  });
+
+  it("renders event cards with name and location", () => {
+    const items: AttendeeEventItem[] = [{ event: MOCK_EVENT, hasStarted: true }];
+    render(<AttendeeContent {...defaultProps} loading={false} events={items} />);
+
+    expect(screen.getByText("Tech Meetup")).toBeInTheDocument();
+    expect(screen.getByText("Room 101")).toBeInTheDocument();
+  });
+
+  it("shows Start Recognition button for started events", () => {
+    const items: AttendeeEventItem[] = [{ event: MOCK_EVENT, hasStarted: true }];
+    render(<AttendeeContent {...defaultProps} loading={false} events={items} />);
+
+    expect(screen.getByText("Start Recognition")).toBeInTheDocument();
+  });
+
+  it("shows message for future events that haven't started", () => {
+    const items: AttendeeEventItem[] = [{ event: FUTURE_EVENT, hasStarted: false }];
+    render(<AttendeeContent {...defaultProps} loading={false} events={items} />);
+
+    expect(screen.getByText("Recognition opens when this event starts")).toBeInTheDocument();
+  });
+
+  it("shows overflow menu with options when opened", () => {
+    const items: AttendeeEventItem[] = [{ event: MOCK_EVENT, hasStarted: true }];
+    render(
+      <AttendeeContent
+        {...defaultProps}
+        loading={false}
+        events={items}
+        openEventMenuId="evt-1"
+      />,
+    );
+
+    expect(screen.getByText("RSVP List")).toBeInTheDocument();
+    expect(screen.getByText("Edit Consents")).toBeInTheDocument();
+    expect(screen.getByText("Leave Event")).toBeInTheDocument();
+  });
+
+  it("calls onLeaveEvent when Leave Event is clicked", async () => {
+    const onLeaveEvent = vi.fn();
+    const items: AttendeeEventItem[] = [{ event: MOCK_EVENT, hasStarted: true }];
+    render(
+      <AttendeeContent
+        {...defaultProps}
+        loading={false}
+        events={items}
+        openEventMenuId="evt-1"
+        onLeaveEvent={onLeaveEvent}
+      />,
+    );
+
+    await userEvent.click(screen.getByText("Leave Event"));
+    expect(onLeaveEvent).toHaveBeenCalledWith(MOCK_EVENT);
+  });
+
+  it("calls onEditConsents when Edit Consents is clicked", async () => {
+    const onEditConsents = vi.fn();
+    const items: AttendeeEventItem[] = [{ event: MOCK_EVENT, hasStarted: true }];
+    render(
+      <AttendeeContent
+        {...defaultProps}
+        loading={false}
+        events={items}
+        openEventMenuId="evt-1"
+        onEditConsents={onEditConsents}
+      />,
+    );
+
+    await userEvent.click(screen.getByText("Edit Consents"));
+    expect(onEditConsents).toHaveBeenCalledWith(MOCK_EVENT);
+  });
+
+  it("calls onStartRecognition when Start Recognition is clicked", async () => {
+    const onStartRecognition = vi.fn();
+    const items: AttendeeEventItem[] = [{ event: MOCK_EVENT, hasStarted: true }];
+    render(
+      <AttendeeContent
+        {...defaultProps}
+        loading={false}
+        events={items}
+        onStartRecognition={onStartRecognition}
+      />,
+    );
+
+    await userEvent.click(screen.getByText("Start Recognition"));
+    expect(onStartRecognition).toHaveBeenCalledWith(MOCK_EVENT);
+  });
+
+  it("shows Leaving state when leavingEventId matches", () => {
+    const items: AttendeeEventItem[] = [{ event: MOCK_EVENT, hasStarted: true }];
+    render(
+      <AttendeeContent
+        {...defaultProps}
+        loading={false}
+        events={items}
+        openEventMenuId="evt-1"
+        leavingEventId="evt-1"
+      />,
+    );
+
+    expect(screen.getByText("Leaving")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/(app)/dashboard/__tests__/create-event-sheet.test.tsx
+++ b/frontend/src/app/(app)/dashboard/__tests__/create-event-sheet.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { CreateEventSheetContent } from "../create-event-sheet-content";
+
+describe("CreateEventSheetContent", () => {
+  it("renders all form fields", () => {
+    render(<CreateEventSheetContent isSubmitting={false} onSubmit={vi.fn()} />);
+
+    expect(screen.getByText("Event Name")).toBeInTheDocument();
+    expect(screen.getByText("Location")).toBeInTheDocument();
+    expect(screen.getByText("Description")).toBeInTheDocument();
+    expect(screen.getByText("Max Participants")).toBeInTheDocument();
+    expect(screen.getByText("Start Date")).toBeInTheDocument();
+    expect(screen.getByText("Start Time")).toBeInTheDocument();
+    expect(screen.getByText("End Date")).toBeInTheDocument();
+    expect(screen.getByText("End Time")).toBeInTheDocument();
+  });
+
+  it("renders Create Event submit button", () => {
+    render(<CreateEventSheetContent isSubmitting={false} onSubmit={vi.fn()} />);
+    expect(screen.getByText("Create Event")).toBeInTheDocument();
+  });
+
+  it("disables submit button when required fields are empty", () => {
+    render(<CreateEventSheetContent isSubmitting={false} onSubmit={vi.fn()} />);
+    expect(screen.getByText("Create Event").closest("button")).toBeDisabled();
+  });
+
+  it("shows Creating text when submitting", () => {
+    render(<CreateEventSheetContent isSubmitting={true} onSubmit={vi.fn()} />);
+    expect(screen.getByText("Creating")).toBeInTheDocument();
+  });
+
+  it("accepts text in the name field", async () => {
+    render(<CreateEventSheetContent isSubmitting={false} onSubmit={vi.fn()} />);
+
+    const nameInput = screen.getByPlaceholderText("Spring Networking Mixer");
+    await userEvent.type(nameInput, "My Event");
+
+    expect(nameInput).toHaveValue("My Event");
+  });
+
+  it("accepts text in the location field", async () => {
+    render(<CreateEventSheetContent isSubmitting={false} onSubmit={vi.fn()} />);
+
+    const locationInput = screen.getByPlaceholderText("Austin Convention Center");
+    await userEvent.type(locationInput, "Room 200");
+
+    expect(locationInput).toHaveValue("Room 200");
+  });
+
+  it("accepts text in the description field", async () => {
+    render(<CreateEventSheetContent isSubmitting={false} onSubmit={vi.fn()} />);
+
+    const descInput = screen.getByPlaceholderText("Tell attendees what this event is about...");
+    await userEvent.type(descInput, "A great event");
+
+    expect(descInput).toHaveValue("A great event");
+  });
+
+  it("marks required fields with asterisk", () => {
+    const { container } = render(
+      <CreateEventSheetContent isSubmitting={false} onSubmit={vi.fn()} />,
+    );
+
+    const requiredMarkers = container.querySelectorAll(".text-red-300");
+    expect(requiredMarkers.length).toBe(5);
+  });
+});

--- a/frontend/src/app/(app)/dashboard/__tests__/dashboard-page.test.tsx
+++ b/frontend/src/app/(app)/dashboard/__tests__/dashboard-page.test.tsx
@@ -1,0 +1,237 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  mockPush,
+  mockRefresh,
+  resetNavigationMocks,
+} from "@/test/mocks/next-navigation";
+import {
+  mockSignOut,
+  resetSupabaseMocks,
+  mockSessionWith,
+  mockNoSession,
+} from "@/test/mocks/supabase";
+
+const mockGetMyEvents = vi.fn();
+const mockGetMyOrganizedEvents = vi.fn();
+const mockGetEvents = vi.fn();
+const mockJoinEvent = vi.fn();
+const mockLeaveEvent = vi.fn();
+const mockCreateEvent = vi.fn();
+const mockDeleteEvent = vi.fn();
+const mockGetMyEventConsent = vi.fn();
+const mockUpdateMyEventConsent = vi.fn();
+const mockGetEventDirectory = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    setToken: vi.fn(),
+    getMyEvents: (...args: unknown[]) => mockGetMyEvents(...args),
+    getMyOrganizedEvents: (...args: unknown[]) => mockGetMyOrganizedEvents(...args),
+    getEvents: (...args: unknown[]) => mockGetEvents(...args),
+    joinEvent: (...args: unknown[]) => mockJoinEvent(...args),
+    leaveEvent: (...args: unknown[]) => mockLeaveEvent(...args),
+    createEvent: (...args: unknown[]) => mockCreateEvent(...args),
+    deleteEvent: (...args: unknown[]) => mockDeleteEvent(...args),
+    getMyEventConsent: (...args: unknown[]) => mockGetMyEventConsent(...args),
+    updateMyEventConsent: (...args: unknown[]) => mockUpdateMyEventConsent(...args),
+    updateEvent: vi.fn(),
+    getEventDirectory: (...args: unknown[]) => mockGetEventDirectory(...args),
+  },
+  ApiError: class extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+    }
+  },
+  isApiErrorWithStatus: (error: unknown, status: number) => {
+    return error instanceof Error && "status" in error && (error as { status: number }).status === status;
+  },
+}));
+
+vi.mock("@/lib/consent-cache", () => ({
+  getCachedEventConsent: vi.fn().mockReturnValue(null),
+  setCachedEventConsent: vi.fn(),
+}));
+
+vi.mock("@/components/aurora", () => ({
+  Aurora: () => <div data-testid="aurora" />,
+}));
+
+const MOCK_EVENT = {
+  event_id: "evt-1",
+  created_by: "organizer-1",
+  name: "Tech Meetup",
+  starts_at: new Date(Date.now() + 86400000).toISOString(),
+  ends_at: new Date(Date.now() + 172800000).toISOString(),
+  location: "Room 101",
+  description: "A tech meetup",
+  max_participants: 50,
+  is_active: true,
+  indexing_status: "completed" as const,
+  cleanup_status: "pending" as const,
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+const MOCK_ORGANIZED_EVENT = {
+  ...MOCK_EVENT,
+  event_id: "evt-org-1",
+  created_by: "user-1",
+  name: "My Organized Event",
+};
+
+import DashboardPage from "../page";
+
+describe("DashboardPage", () => {
+  beforeEach(() => {
+    resetNavigationMocks();
+    resetSupabaseMocks();
+    mockGetMyEvents.mockClear();
+    mockGetMyOrganizedEvents.mockClear();
+    mockGetEvents.mockClear();
+    mockSignOut.mockClear();
+  });
+
+  it("shows loading spinner initially", () => {
+    mockSessionWith();
+    mockGetMyEvents.mockImplementation(() => new Promise(() => {}));
+    mockGetMyOrganizedEvents.mockImplementation(() => new Promise(() => {}));
+
+    render(<DashboardPage />);
+
+    const spinners = document.querySelectorAll(".animate-spin");
+    expect(spinners.length).toBeGreaterThan(0);
+  });
+
+  it("renders events list after loading", async () => {
+    mockSessionWith();
+    mockGetMyEvents.mockResolvedValue([MOCK_EVENT]);
+    mockGetMyOrganizedEvents.mockResolvedValue([]);
+
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Tech Meetup")).toBeInTheDocument();
+    });
+  });
+
+  it("renders event location", async () => {
+    mockSessionWith();
+    mockGetMyEvents.mockResolvedValue([MOCK_EVENT]);
+    mockGetMyOrganizedEvents.mockResolvedValue([]);
+
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Room 101")).toBeInTheDocument();
+    });
+  });
+
+  it("shows empty state when no events", async () => {
+    mockSessionWith();
+    mockGetMyEvents.mockResolvedValue([]);
+    mockGetMyOrganizedEvents.mockResolvedValue([]);
+
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No upcoming events found")).toBeInTheDocument();
+    });
+  });
+
+  it("renders Attendee and Organizer tab buttons", async () => {
+    mockSessionWith();
+    mockGetMyEvents.mockResolvedValue([MOCK_EVENT]);
+    mockGetMyOrganizedEvents.mockResolvedValue([MOCK_ORGANIZED_EVENT]);
+
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Attendee")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Organizer")).toBeInTheDocument();
+  });
+
+  it("switches to organizer tab and shows organized events", async () => {
+    mockSessionWith();
+    mockGetMyEvents.mockResolvedValue([MOCK_EVENT]);
+    mockGetMyOrganizedEvents.mockResolvedValue([MOCK_ORGANIZED_EVENT]);
+
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Organizer")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText("Organizer"));
+
+    await waitFor(() => {
+      expect(screen.getByText("My Organized Event")).toBeInTheDocument();
+    });
+  });
+
+  it("switches back to attendee tab", async () => {
+    mockSessionWith();
+    mockGetMyEvents.mockResolvedValue([MOCK_EVENT]);
+    mockGetMyOrganizedEvents.mockResolvedValue([MOCK_ORGANIZED_EVENT]);
+
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Organizer")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText("Organizer"));
+    await userEvent.click(screen.getByText("Attendee"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Tech Meetup")).toBeInTheDocument();
+    });
+  });
+
+  it("renders sign out icon button", async () => {
+    mockSessionWith();
+    mockGetMyEvents.mockResolvedValue([]);
+    mockGetMyOrganizedEvents.mockResolvedValue([]);
+
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      const logOutIcons = document.querySelectorAll(".lucide-log-out");
+      expect(logOutIcons.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("handles no session gracefully", async () => {
+    mockNoSession();
+    mockGetMyEvents.mockResolvedValue([]);
+    mockGetMyOrganizedEvents.mockResolvedValue([]);
+
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No upcoming events found")).toBeInTheDocument();
+    });
+  });
+
+  it("renders discover and create buttons for organizer tab", async () => {
+    mockSessionWith();
+    mockGetMyEvents.mockResolvedValue([]);
+    mockGetMyOrganizedEvents.mockResolvedValue([]);
+
+    render(<DashboardPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Organizer")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText("Organizer"));
+
+    await waitFor(() => {
+      const plusIcons = document.querySelectorAll(".lucide-plus");
+      expect(plusIcons.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/frontend/src/app/(app)/dashboard/__tests__/event-consents-sheet.test.tsx
+++ b/frontend/src/app/(app)/dashboard/__tests__/event-consents-sheet.test.tsx
@@ -1,0 +1,207 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { EventConsentsSheetContent } from "../event-consents-sheet-content";
+
+const MOCK_CONSENT = {
+  event_id: "evt-1",
+  user_id: "user-1",
+  allow_profile_display: true,
+  allow_recognition: true,
+  consented_at: "2026-01-01T00:00:00Z",
+  revoked_at: null,
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+describe("EventConsentsSheetContent", () => {
+  it("shows loading spinner when loading", () => {
+    render(
+      <EventConsentsSheetContent
+        loading={true}
+        saving={false}
+        consent={null}
+        onToggleProfileDisplay={vi.fn()}
+        onToggleRecognition={vi.fn()}
+        onGrantAll={vi.fn()}
+        onRevokeAll={vi.fn()}
+      />,
+    );
+
+    const spinners = document.querySelectorAll(".animate-spin");
+    expect(spinners.length).toBeGreaterThan(0);
+  });
+
+  it("shows error message when consent is null", () => {
+    render(
+      <EventConsentsSheetContent
+        loading={false}
+        saving={false}
+        consent={null}
+        onToggleProfileDisplay={vi.fn()}
+        onToggleRecognition={vi.fn()}
+        onGrantAll={vi.fn()}
+        onRevokeAll={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Could not load your event consent settings.")).toBeInTheDocument();
+  });
+
+  it("renders Profile Display and Face Recognition toggles", () => {
+    render(
+      <EventConsentsSheetContent
+        loading={false}
+        saving={false}
+        consent={MOCK_CONSENT}
+        onToggleProfileDisplay={vi.fn()}
+        onToggleRecognition={vi.fn()}
+        onGrantAll={vi.fn()}
+        onRevokeAll={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Profile Display")).toBeInTheDocument();
+    expect(screen.getByText("Face Recognition")).toBeInTheDocument();
+  });
+
+  it("renders Grant All and Revoke All buttons", () => {
+    render(
+      <EventConsentsSheetContent
+        loading={false}
+        saving={false}
+        consent={MOCK_CONSENT}
+        onToggleProfileDisplay={vi.fn()}
+        onToggleRecognition={vi.fn()}
+        onGrantAll={vi.fn()}
+        onRevokeAll={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Grant All")).toBeInTheDocument();
+    expect(screen.getByText("Revoke All")).toBeInTheDocument();
+  });
+
+  it("calls onToggleProfileDisplay when Profile Display toggle is clicked", async () => {
+    const onToggleProfileDisplay = vi.fn();
+    render(
+      <EventConsentsSheetContent
+        loading={false}
+        saving={false}
+        consent={MOCK_CONSENT}
+        onToggleProfileDisplay={onToggleProfileDisplay}
+        onToggleRecognition={vi.fn()}
+        onGrantAll={vi.fn()}
+        onRevokeAll={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(screen.getByLabelText("Profile Display"));
+    expect(onToggleProfileDisplay).toHaveBeenCalledWith(false);
+  });
+
+  it("calls onToggleRecognition when Face Recognition toggle is clicked", async () => {
+    const onToggleRecognition = vi.fn();
+    render(
+      <EventConsentsSheetContent
+        loading={false}
+        saving={false}
+        consent={MOCK_CONSENT}
+        onToggleProfileDisplay={vi.fn()}
+        onToggleRecognition={onToggleRecognition}
+        onGrantAll={vi.fn()}
+        onRevokeAll={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(screen.getByLabelText("Face Recognition"));
+    expect(onToggleRecognition).toHaveBeenCalledWith(false);
+  });
+
+  it("calls onGrantAll when Grant All is clicked", async () => {
+    const consent = { ...MOCK_CONSENT, allow_profile_display: false, allow_recognition: false };
+    const onGrantAll = vi.fn();
+    render(
+      <EventConsentsSheetContent
+        loading={false}
+        saving={false}
+        consent={consent}
+        onToggleProfileDisplay={vi.fn()}
+        onToggleRecognition={vi.fn()}
+        onGrantAll={onGrantAll}
+        onRevokeAll={vi.fn()}
+      />,
+    );
+
+    await userEvent.click(screen.getByText("Grant All"));
+    expect(onGrantAll).toHaveBeenCalledOnce();
+  });
+
+  it("calls onRevokeAll when Revoke All is clicked", async () => {
+    const onRevokeAll = vi.fn();
+    render(
+      <EventConsentsSheetContent
+        loading={false}
+        saving={false}
+        consent={MOCK_CONSENT}
+        onToggleProfileDisplay={vi.fn()}
+        onToggleRecognition={vi.fn()}
+        onGrantAll={vi.fn()}
+        onRevokeAll={onRevokeAll}
+      />,
+    );
+
+    await userEvent.click(screen.getByText("Revoke All"));
+    expect(onRevokeAll).toHaveBeenCalledOnce();
+  });
+
+  it("disables Grant All when both consents are already on", () => {
+    render(
+      <EventConsentsSheetContent
+        loading={false}
+        saving={false}
+        consent={MOCK_CONSENT}
+        onToggleProfileDisplay={vi.fn()}
+        onToggleRecognition={vi.fn()}
+        onGrantAll={vi.fn()}
+        onRevokeAll={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Grant All").closest("button")).toBeDisabled();
+  });
+
+  it("disables Revoke All when both consents are already off", () => {
+    const consent = { ...MOCK_CONSENT, allow_profile_display: false, allow_recognition: false };
+    render(
+      <EventConsentsSheetContent
+        loading={false}
+        saving={false}
+        consent={consent}
+        onToggleProfileDisplay={vi.fn()}
+        onToggleRecognition={vi.fn()}
+        onGrantAll={vi.fn()}
+        onRevokeAll={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Revoke All").closest("button")).toBeDisabled();
+  });
+
+  it("shows info text about consent usage", () => {
+    render(
+      <EventConsentsSheetContent
+        loading={false}
+        saving={false}
+        consent={MOCK_CONSENT}
+        onToggleProfileDisplay={vi.fn()}
+        onToggleRecognition={vi.fn()}
+        onGrantAll={vi.fn()}
+        onRevokeAll={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText("Update how this event can use your profile and face recognition data."),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/(app)/dashboard/__tests__/event-detail-sheet.test.tsx
+++ b/frontend/src/app/(app)/dashboard/__tests__/event-detail-sheet.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { EventDetailSheetContent } from "../event-detail-sheet-content";
+
+const MOCK_EVENT = {
+  event_id: "evt-1",
+  created_by: "org-1",
+  name: "Spring Demo Day",
+  starts_at: "2026-05-15T14:00:00Z",
+  ends_at: "2026-05-15T18:00:00Z",
+  location: "Engineering Hall 101",
+  description: "Annual ECE demo day showcase",
+  max_participants: 200,
+  is_active: true,
+  indexing_status: "completed" as const,
+  cleanup_status: "pending" as const,
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+const formatEventDate = (v: string) =>
+  new Date(v).toLocaleString("en-US", { dateStyle: "medium", timeStyle: "short" });
+
+describe("EventDetailSheetContent", () => {
+  it("renders event name", () => {
+    render(<EventDetailSheetContent event={MOCK_EVENT} formatEventDate={formatEventDate} />);
+    expect(screen.getByText("Spring Demo Day")).toBeInTheDocument();
+  });
+
+  it("renders location", () => {
+    render(<EventDetailSheetContent event={MOCK_EVENT} formatEventDate={formatEventDate} />);
+    expect(screen.getByText("Engineering Hall 101")).toBeInTheDocument();
+  });
+
+  it("renders description", () => {
+    render(<EventDetailSheetContent event={MOCK_EVENT} formatEventDate={formatEventDate} />);
+    expect(screen.getByText("Annual ECE demo day showcase")).toBeInTheDocument();
+    expect(screen.getByText("Description")).toBeInTheDocument();
+  });
+
+  it("renders max participants", () => {
+    render(<EventDetailSheetContent event={MOCK_EVENT} formatEventDate={formatEventDate} />);
+    expect(screen.getByText("200")).toBeInTheDocument();
+    expect(screen.getByText("Max Participants")).toBeInTheDocument();
+  });
+
+  it("renders start and end labels", () => {
+    render(<EventDetailSheetContent event={MOCK_EVENT} formatEventDate={formatEventDate} />);
+    expect(screen.getByText("Starts")).toBeInTheDocument();
+    expect(screen.getByText("Ends")).toBeInTheDocument();
+  });
+
+  it("shows Inactive badge when event is not active", () => {
+    const inactiveEvent = { ...MOCK_EVENT, is_active: false };
+    render(<EventDetailSheetContent event={inactiveEvent} formatEventDate={formatEventDate} />);
+    expect(screen.getByText("Inactive")).toBeInTheDocument();
+  });
+
+  it("does not show Inactive badge when event is active", () => {
+    render(<EventDetailSheetContent event={MOCK_EVENT} formatEventDate={formatEventDate} />);
+    expect(screen.queryByText("Inactive")).not.toBeInTheDocument();
+  });
+
+  it("hides description section when no description", () => {
+    const noDesc = { ...MOCK_EVENT, description: null };
+    render(<EventDetailSheetContent event={noDesc} formatEventDate={formatEventDate} />);
+    expect(screen.queryByText("Description")).not.toBeInTheDocument();
+  });
+
+  it("hides max participants when not set", () => {
+    const noMax = { ...MOCK_EVENT, max_participants: null };
+    render(<EventDetailSheetContent event={noMax} formatEventDate={formatEventDate} />);
+    expect(screen.queryByText("Max Participants")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/(app)/dashboard/__tests__/organizer-dashboard.test.tsx
+++ b/frontend/src/app/(app)/dashboard/__tests__/organizer-dashboard.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { OrganizerControls, OrganizerContent } from "../organizer-dashboard";
+
+const ACTIVE_EVENT = {
+  event_id: "evt-org-1",
+  created_by: "user-1",
+  name: "Spring Demo Day",
+  starts_at: new Date(Date.now() + 86400000).toISOString(),
+  ends_at: new Date(Date.now() + 172800000).toISOString(),
+  location: "Main Hall",
+  description: "Annual demo day",
+  max_participants: 100,
+  is_active: true,
+  indexing_status: "completed" as const,
+  cleanup_status: "pending" as const,
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+const INACTIVE_EVENT = {
+  ...ACTIVE_EVENT,
+  event_id: "evt-org-2",
+  name: "Archived Workshop",
+  is_active: false,
+};
+
+describe("OrganizerControls", () => {
+  it("renders Create Event button", () => {
+    render(<OrganizerControls onCreateEvent={vi.fn()} />);
+    expect(screen.getByText("Create Event")).toBeInTheDocument();
+  });
+
+  it("calls onCreateEvent when clicked", async () => {
+    const onCreateEvent = vi.fn();
+    render(<OrganizerControls onCreateEvent={onCreateEvent} />);
+
+    await userEvent.click(screen.getByText("Create Event"));
+    expect(onCreateEvent).toHaveBeenCalledOnce();
+  });
+});
+
+describe("OrganizerContent", () => {
+  const defaultProps = {
+    formatEventDate: (v: string) => new Date(v).toLocaleDateString(),
+    deletingEventId: null,
+    archivingEventId: null,
+    unarchivingEventId: null,
+    onViewEventDetail: vi.fn(),
+    onEditEventRequest: vi.fn(),
+    onViewRsvpList: vi.fn(),
+    onArchiveEvent: vi.fn().mockResolvedValue(undefined),
+    onUnarchiveEvent: vi.fn().mockResolvedValue(undefined),
+    onDeleteEvent: vi.fn().mockResolvedValue(undefined),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows No active events when list is empty", () => {
+    render(<OrganizerContent {...defaultProps} events={[]} />);
+    expect(screen.getByText("No active events")).toBeInTheDocument();
+  });
+
+  it("renders active event name and location", () => {
+    render(<OrganizerContent {...defaultProps} events={[ACTIVE_EVENT]} />);
+
+    expect(screen.getByText("Spring Demo Day")).toBeInTheDocument();
+    expect(screen.getByText("Main Hall")).toBeInTheDocument();
+  });
+
+  it("shows Active Events section header", () => {
+    render(<OrganizerContent {...defaultProps} events={[ACTIVE_EVENT]} />);
+    expect(screen.getByText("Active Events")).toBeInTheDocument();
+  });
+
+  it("shows Inactive Events section when inactive events exist", () => {
+    render(<OrganizerContent {...defaultProps} events={[ACTIVE_EVENT, INACTIVE_EVENT]} />);
+
+    expect(screen.getByText("Active Events")).toBeInTheDocument();
+    expect(screen.getByText("Inactive Events")).toBeInTheDocument();
+    expect(screen.getByText("Archived Workshop")).toBeInTheDocument();
+  });
+
+  it("shows overflow menu with edit, RSVP, archive, delete for active events", async () => {
+    render(<OrganizerContent {...defaultProps} events={[ACTIVE_EVENT]} />);
+
+    await userEvent.click(screen.getByLabelText("Organizer event actions"));
+
+    expect(screen.getByText("Edit Event")).toBeInTheDocument();
+    expect(screen.getByText("RSVP List")).toBeInTheDocument();
+    expect(screen.getByText("Archive Event")).toBeInTheDocument();
+    expect(screen.getByText("Delete Event")).toBeInTheDocument();
+  });
+
+  it("shows delete confirmation dialog when Delete Event is clicked", async () => {
+    render(<OrganizerContent {...defaultProps} events={[ACTIVE_EVENT]} />);
+
+    await userEvent.click(screen.getByLabelText("Organizer event actions"));
+    await userEvent.click(screen.getByText("Delete Event"));
+
+    expect(screen.getByText("Delete Event?")).toBeInTheDocument();
+    expect(screen.getByText(/permanently delete "Spring Demo Day"/)).toBeInTheDocument();
+  });
+
+  it("shows archive confirmation dialog when Archive Event is clicked", async () => {
+    render(<OrganizerContent {...defaultProps} events={[ACTIVE_EVENT]} />);
+
+    await userEvent.click(screen.getByLabelText("Organizer event actions"));
+    await userEvent.click(screen.getByText("Archive Event"));
+
+    expect(screen.getByText("Archive Event?")).toBeInTheDocument();
+    expect(screen.getByText(/hide "Spring Demo Day" from active events/)).toBeInTheDocument();
+  });
+
+  it("shows Unarchive Event option for inactive events", async () => {
+    render(<OrganizerContent {...defaultProps} events={[INACTIVE_EVENT]} />);
+
+    const buttons = screen.getAllByLabelText("Organizer event actions");
+    await userEvent.click(buttons[0]);
+
+    expect(screen.getByText("Unarchive Event")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/(app)/onboarding/__tests__/onboarding-page.test.tsx
+++ b/frontend/src/app/(app)/onboarding/__tests__/onboarding-page.test.tsx
@@ -1,0 +1,196 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  mockBack,
+  mockReplace,
+  mockPush,
+  resetNavigationMocks,
+} from "@/test/mocks/next-navigation";
+import {
+  resetSupabaseMocks,
+  mockSessionWith,
+} from "@/test/mocks/supabase";
+
+const mockGetProfile = vi.fn();
+const mockOnboardFromLinkedIn = vi.fn();
+const mockUploadResume = vi.fn();
+const mockGetProfileCompletion = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    setToken: vi.fn(),
+    getProfile: (...args: unknown[]) => mockGetProfile(...args),
+    onboardFromLinkedIn: (...args: unknown[]) => mockOnboardFromLinkedIn(...args),
+    uploadResume: (...args: unknown[]) => mockUploadResume(...args),
+    getProfileCompletion: (...args: unknown[]) => mockGetProfileCompletion(...args),
+    updateProfile: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+vi.mock("@/components/aurora", () => ({
+  Aurora: () => <div data-testid="aurora" />,
+}));
+
+import OnboardingPage from "../page";
+
+describe("OnboardingPage", () => {
+  beforeEach(() => {
+    resetNavigationMocks();
+    resetSupabaseMocks();
+    mockGetProfile.mockClear();
+    mockOnboardFromLinkedIn.mockClear();
+    mockUploadResume.mockClear();
+    mockGetProfileCompletion.mockClear();
+  });
+
+  it("renders the build your profile heading", async () => {
+    mockSessionWith();
+    mockGetProfile.mockRejectedValue(new Error("no profile"));
+
+    render(<OnboardingPage />);
+
+    expect(screen.getByText("Build your profile")).toBeInTheDocument();
+  });
+
+  it("renders LinkedIn URL and Resume source options", async () => {
+    mockSessionWith();
+    mockGetProfile.mockRejectedValue(new Error("no profile"));
+
+    render(<OnboardingPage />);
+
+    expect(screen.getAllByText("LinkedIn URL").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Resume").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows step indicator", async () => {
+    mockSessionWith();
+    mockGetProfile.mockRejectedValue(new Error("no profile"));
+
+    render(<OnboardingPage />);
+
+    expect(screen.getByText("Step 1 of 8")).toBeInTheDocument();
+  });
+
+  it("shows description text", async () => {
+    mockSessionWith();
+    mockGetProfile.mockRejectedValue(new Error("no profile"));
+
+    const { container } = render(<OnboardingPage />);
+
+    expect(container.textContent).toContain("pull in your name, photo, and work history");
+  });
+
+  it("shows Import Profile button when LinkedIn URL has value", async () => {
+    mockSessionWith();
+    mockGetProfile.mockRejectedValue(new Error("no profile"));
+
+    render(<OnboardingPage />);
+
+    const input = screen.getByPlaceholderText("yourname");
+    await userEvent.type(input, "johndoe");
+
+    expect(screen.getByText("Import Profile")).toBeInTheDocument();
+  });
+
+  it("redirects to dashboard if profile already exists", async () => {
+    mockSessionWith();
+    mockGetProfile.mockResolvedValue({ user_id: "u1", full_name: "Test" });
+
+    render(<OnboardingPage />);
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+
+  it("shows error for invalid LinkedIn username", async () => {
+    mockSessionWith();
+    mockGetProfile.mockRejectedValue(new Error("no profile"));
+
+    render(<OnboardingPage />);
+
+    const input = screen.getByPlaceholderText("yourname");
+    await userEvent.type(input, "a");
+
+    await userEvent.click(screen.getByText("Import Profile"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Please enter a valid LinkedIn username (letters, numbers, and hyphens only)."
+        )
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("submits LinkedIn URL and shows preview", async () => {
+    mockSessionWith();
+    mockGetProfile.mockRejectedValue(new Error("no profile"));
+    mockOnboardFromLinkedIn.mockResolvedValue({
+      profile: {
+        user_id: "u1",
+        full_name: "John Doe",
+        headline: "Engineer",
+        bio: null,
+        location: null,
+        company: null,
+        major: null,
+        graduation_year: null,
+        linkedin_url: "https://linkedin.com/in/johndoe",
+        photo_path: null,
+        experiences: [],
+        education: [],
+        profile_one_liner: null,
+        profile_summary: null,
+      },
+      completion: {
+        is_complete: false,
+        completion_score: 40,
+        missing_fields: ["bio", "location", "profile_pic"],
+      },
+      enrichment: {},
+      image_saved: false,
+    });
+
+    render(<OnboardingPage />);
+
+    const input = screen.getByPlaceholderText("yourname");
+    await userEvent.type(input, "johndoe");
+
+    await userEvent.click(screen.getByText("Import Profile"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Confirm your info")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("John Doe")).toBeInTheDocument();
+  });
+
+  it("shows error when LinkedIn import fails", async () => {
+    mockSessionWith();
+    mockGetProfile.mockRejectedValue(new Error("no profile"));
+    mockOnboardFromLinkedIn.mockRejectedValue(new Error("Profile not found"));
+
+    render(<OnboardingPage />);
+
+    const input = screen.getByPlaceholderText("yourname");
+    await userEvent.type(input, "validuser");
+
+    await userEvent.click(screen.getByText("Import Profile"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Profile not found")).toBeInTheDocument();
+    });
+  });
+
+  it("has a back button", async () => {
+    mockSessionWith();
+    mockGetProfile.mockRejectedValue(new Error("no profile"));
+
+    render(<OnboardingPage />);
+
+    const backBtns = document.querySelectorAll(".lucide-chevron-left");
+    expect(backBtns.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/app/(app)/profile/__tests__/profile-page.test.tsx
+++ b/frontend/src/app/(app)/profile/__tests__/profile-page.test.tsx
@@ -1,0 +1,227 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  mockPush,
+  mockRefresh,
+  resetNavigationMocks,
+} from "@/test/mocks/next-navigation";
+import {
+  mockSignOut,
+  resetSupabaseMocks,
+  mockSessionWith,
+} from "@/test/mocks/supabase";
+
+const mockGetProfile = vi.fn();
+const mockUpdateProfile = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    setToken: vi.fn(),
+    getProfile: (...args: unknown[]) => mockGetProfile(...args),
+    updateProfile: (...args: unknown[]) => mockUpdateProfile(...args),
+  },
+}));
+
+vi.mock("@/lib/profile-photo-upload", () => ({
+  uploadProfilePhoto: vi.fn(),
+}));
+
+vi.mock("@/lib/use-profile-photo-url", () => ({
+  useProfilePhotoUrl: (path: string | null) => ({
+    photoUrl: path,
+    handleImageError: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/aurora", () => ({
+  Aurora: () => <div data-testid="aurora" />,
+}));
+
+const MOCK_PROFILE = {
+  user_id: "user-1",
+  full_name: "Jane Smith",
+  headline: "Product Manager",
+  bio: "I build things",
+  location: "New York",
+  company: "Acme Corp",
+  major: "Business",
+  graduation_year: 2022,
+  linkedin_url: "https://linkedin.com/in/jane",
+  photo_path: null,
+  experiences: [
+    {
+      company: "Acme Corp",
+      title: "PM",
+      start_date: "2022-01",
+      end_date: null,
+      description: null,
+      location: null,
+    },
+  ],
+  education: [
+    {
+      school: "NYU",
+      degree: "MBA",
+      field_of_study: "Business",
+      start_date: "2020",
+      end_date: "2022",
+    },
+  ],
+  profile_one_liner: null,
+  profile_summary: null,
+};
+
+import ProfilePage from "../page";
+
+describe("ProfilePage", () => {
+  beforeEach(() => {
+    resetNavigationMocks();
+    resetSupabaseMocks();
+    mockGetProfile.mockClear();
+    mockUpdateProfile.mockClear();
+    mockSignOut.mockClear();
+  });
+
+  it("renders profile data after loading", async () => {
+    mockSessionWith();
+    mockGetProfile.mockResolvedValue(MOCK_PROFILE);
+
+    render(<ProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Jane Smith")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Product Manager")).toBeInTheDocument();
+    expect(screen.getByText("I build things")).toBeInTheDocument();
+    expect(screen.getByText("New York")).toBeInTheDocument();
+  });
+
+  it("shows initials when no photo", async () => {
+    mockSessionWith();
+    mockGetProfile.mockResolvedValue(MOCK_PROFILE);
+
+    render(<ProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("JS")).toBeInTheDocument();
+    });
+  });
+
+  it("renders section labels", async () => {
+    mockSessionWith();
+    mockGetProfile.mockResolvedValue(MOCK_PROFILE);
+
+    render(<ProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("About")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Location")).toBeInTheDocument();
+    expect(screen.getByText("Work")).toBeInTheDocument();
+    expect(screen.getByText("Education")).toBeInTheDocument();
+  });
+
+  it("renders experience entries", async () => {
+    mockSessionWith();
+    mockGetProfile.mockResolvedValue(MOCK_PROFILE);
+
+    render(<ProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("PM")).toBeInTheDocument();
+    });
+  });
+
+  it("renders education entries", async () => {
+    mockSessionWith();
+    mockGetProfile.mockResolvedValue(MOCK_PROFILE);
+
+    render(<ProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("NYU")).toBeInTheDocument();
+    });
+    expect(screen.getByText("MBA, Business")).toBeInTheDocument();
+  });
+
+  it("shows sign out button", async () => {
+    mockSessionWith();
+    mockGetProfile.mockResolvedValue(MOCK_PROFILE);
+
+    render(<ProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Sign Out")).toBeInTheDocument();
+    });
+  });
+
+  it("shows sign out confirmation when clicked", async () => {
+    mockSessionWith();
+    mockGetProfile.mockResolvedValue(MOCK_PROFILE);
+
+    render(<ProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Sign Out")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText("Sign Out"));
+
+    expect(screen.getByText("Yes, sign out")).toBeInTheDocument();
+    expect(screen.getByText("Cancel")).toBeInTheDocument();
+  });
+
+  it("cancels sign out confirmation", async () => {
+    mockSessionWith();
+    mockGetProfile.mockResolvedValue(MOCK_PROFILE);
+
+    render(<ProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Sign Out")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText("Sign Out"));
+    await userEvent.click(screen.getByText("Cancel"));
+
+    expect(screen.queryByText("Yes, sign out")).not.toBeInTheDocument();
+    expect(screen.getByText("Sign Out")).toBeInTheDocument();
+  });
+
+  it("calls supabase signOut and redirects", async () => {
+    mockSessionWith();
+    mockGetProfile.mockResolvedValue(MOCK_PROFILE);
+    mockSignOut.mockResolvedValue({ error: null });
+
+    render(<ProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Sign Out")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText("Sign Out"));
+    await userEvent.click(screen.getByText("Yes, sign out"));
+
+    await waitFor(() => {
+      expect(mockSignOut).toHaveBeenCalled();
+      expect(mockPush).toHaveBeenCalledWith("/");
+    });
+  });
+
+  it("opens edit mode when clicking a field", async () => {
+    mockSessionWith();
+    mockGetProfile.mockResolvedValue(MOCK_PROFILE);
+
+    render(<ProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("I build things")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText("I build things"));
+
+    expect(screen.getByDisplayValue("I build things")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/(app)/profile/__tests__/user-profile-page.test.tsx
+++ b/frontend/src/app/(app)/profile/__tests__/user-profile-page.test.tsx
@@ -1,0 +1,225 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  mockPush,
+  mockBack,
+  mockParams,
+  resetNavigationMocks,
+} from "@/test/mocks/next-navigation";
+import {
+  mockGetSession,
+  resetSupabaseMocks,
+  mockSessionWith,
+  mockNoSession,
+} from "@/test/mocks/supabase";
+
+const mockGetProfileById = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    setToken: vi.fn(),
+    getProfileById: (...args: unknown[]) => mockGetProfileById(...args),
+    getMyProfileLikes: vi.fn().mockResolvedValue([]),
+  },
+  isApiErrorWithStatus: () => false,
+}));
+
+vi.mock("@/components/aurora", () => ({
+  Aurora: () => <div data-testid="aurora" />,
+}));
+
+const MOCK_PROFILE = {
+  user_id: "user-123",
+  full_name: "Akash Kumar",
+  headline: "Software Engineer at Google",
+  bio: "Building cool stuff",
+  location: "San Francisco, CA",
+  company: "Google",
+  major: "Computer Science",
+  graduation_year: 2024,
+  linkedin_url: "https://linkedin.com/in/akash",
+  photo_path: "https://example.com/photo.jpg",
+  experiences: [
+    {
+      company: "Google",
+      title: "Software Engineer",
+      start_date: "2024-06",
+      end_date: null,
+      description: null,
+      location: "SF",
+    },
+  ],
+  education: [
+    {
+      school: "Purdue University",
+      degree: "BS",
+      field_of_study: "Computer Science",
+      start_date: "2020-08",
+      end_date: "2024-05",
+    },
+  ],
+  profile_one_liner: null,
+  profile_summary: "Experienced software engineer",
+};
+
+import UserProfilePage from "../[userId]/page";
+
+describe("UserProfilePage", () => {
+  beforeEach(() => {
+    resetNavigationMocks();
+    resetSupabaseMocks();
+    mockGetProfileById.mockClear();
+    mockParams.mockReturnValue({ userId: "user-123" });
+    sessionStorage.clear();
+  });
+
+  it("redirects to login when no session", async () => {
+    mockNoSession();
+    mockGetProfileById.mockRejectedValue(new Error("no auth"));
+
+    render(<UserProfilePage />);
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/login");
+    });
+  });
+
+  it("renders profile data after loading", async () => {
+    mockSessionWith();
+    mockGetProfileById.mockResolvedValue(MOCK_PROFILE);
+
+    render(<UserProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Akash Kumar")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Software Engineer at Google")).toBeInTheDocument();
+    expect(screen.getByText("San Francisco, CA")).toBeInTheDocument();
+    expect(screen.getByText("Building cool stuff")).toBeInTheDocument();
+  });
+
+  it("renders experience section", async () => {
+    mockSessionWith();
+    mockGetProfileById.mockResolvedValue(MOCK_PROFILE);
+
+    render(<UserProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Software Engineer")).toBeInTheDocument();
+    });
+  });
+
+  it("renders education section", async () => {
+    mockSessionWith();
+    mockGetProfileById.mockResolvedValue(MOCK_PROFILE);
+
+    render(<UserProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Purdue University")).toBeInTheDocument();
+    });
+    expect(screen.getByText("BS, Computer Science")).toBeInTheDocument();
+  });
+
+  it("renders LinkedIn link", async () => {
+    mockSessionWith();
+    mockGetProfileById.mockResolvedValue(MOCK_PROFILE);
+
+    render(<UserProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("LinkedIn")).toBeInTheDocument();
+    });
+    const link = screen.getByText("LinkedIn").closest("a");
+    expect(link).toHaveAttribute("href", "https://linkedin.com/in/akash");
+    expect(link).toHaveAttribute("target", "_blank");
+  });
+
+  it("renders profile summary section when present", async () => {
+    mockSessionWith();
+    mockGetProfileById.mockResolvedValue(MOCK_PROFILE);
+
+    render(<UserProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Experienced software engineer")).toBeInTheDocument();
+    });
+  });
+
+  it("navigates back when back button is clicked", async () => {
+    mockSessionWith();
+    mockGetProfileById.mockResolvedValue(MOCK_PROFILE);
+
+    render(<UserProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Back")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText("Back"));
+    expect(mockBack).toHaveBeenCalled();
+  });
+
+  it("shows initials when no photo", async () => {
+    mockSessionWith();
+    mockGetProfileById.mockResolvedValue({
+      ...MOCK_PROFILE,
+      photo_path: null,
+    });
+
+    render(<UserProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("AK")).toBeInTheDocument();
+    });
+  });
+
+  it("shows profile not found when API returns null", async () => {
+    mockSessionWith();
+    mockGetProfileById.mockRejectedValue(new Error("Not found"));
+
+    render(<UserProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Profile not found")).toBeInTheDocument();
+    });
+  });
+
+  it("reads cached profile from sessionStorage", () => {
+    const cached = { ...MOCK_PROFILE, full_name: "Cached Name" };
+    sessionStorage.setItem("profile_cache_user-123", JSON.stringify(cached));
+
+    const stored = sessionStorage.getItem("profile_cache_user-123");
+    expect(stored).not.toBeNull();
+    const parsed = JSON.parse(stored!);
+    expect(parsed.full_name).toBe("Cached Name");
+  });
+
+  it("hides optional sections when data is absent", async () => {
+    mockSessionWith();
+    mockGetProfileById.mockResolvedValue({
+      ...MOCK_PROFILE,
+      bio: null,
+      location: null,
+      company: null,
+      major: null,
+      experiences: null,
+      education: null,
+      linkedin_url: null,
+      profile_summary: null,
+    });
+
+    render(<UserProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Akash Kumar")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("About")).not.toBeInTheDocument();
+    expect(screen.queryByText("Location")).not.toBeInTheDocument();
+    expect(screen.queryByText("LinkedIn")).not.toBeInTheDocument();
+    expect(screen.queryByText("Summary")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/(app)/profile/page.tsx
+++ b/frontend/src/app/(app)/profile/page.tsx
@@ -17,6 +17,7 @@ import {
   GraduationCap,
   Pencil,
   LogOut,
+  Link2,
 } from "lucide-react";
 
 export default function ProfilePage() {
@@ -299,6 +300,32 @@ export default function ProfilePage() {
               onSave={saveEdit}
               onDraftChange={setDraftValue}
               placeholder="Add a location"
+              displayClassName="text-[14px] text-white/60"
+              inputClassName="w-full bg-transparent text-[14px] text-white/80 outline-none"
+            />
+          </SectionCard>
+
+          {/* LinkedIn */}
+          <SectionCard
+            label="LinkedIn"
+            icon={<Link2 className="h-3.5 w-3.5" />}
+            onEdit={
+              editField !== "linkedin_url"
+                ? () => startEdit("linkedin_url", profile.linkedin_url ?? "")
+                : undefined
+            }
+          >
+            <FieldEditor
+              field="linkedin_url"
+              value={profile.linkedin_url ?? ""}
+              editField={editField}
+              draftValue={draftValue}
+              saving={saving}
+              onStart={startEdit}
+              onCancel={cancelEdit}
+              onSave={saveEdit}
+              onDraftChange={setDraftValue}
+              placeholder="Add a LinkedIn URL"
               displayClassName="text-[14px] text-white/60"
               inputClassName="w-full bg-transparent text-[14px] text-white/80 outline-none"
             />

--- a/frontend/src/app/(app)/recognition/__tests__/recognition-page.test.tsx
+++ b/frontend/src/app/(app)/recognition/__tests__/recognition-page.test.tsx
@@ -1,0 +1,511 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  mockPush,
+  mockRefresh,
+  resetNavigationMocks,
+} from "@/test/mocks/next-navigation";
+import {
+  mockSignOut,
+  resetSupabaseMocks,
+  mockSessionWith,
+  mockNoSession,
+} from "@/test/mocks/supabase";
+
+const mockGetMyEventConsent = vi.fn();
+const mockGetCompatibility = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    setToken: vi.fn(),
+    getMyEventConsent: (...args: unknown[]) => mockGetMyEventConsent(...args),
+    getCompatibility: (...args: unknown[]) => mockGetCompatibility(...args),
+  },
+}));
+
+vi.mock("@/lib/consent-cache", () => ({
+  getCachedEventConsent: vi.fn().mockReturnValue(null),
+  setCachedEventConsent: vi.fn(),
+}));
+
+vi.mock("@/components/aurora", () => ({
+  Aurora: () => <div data-testid="aurora" />,
+}));
+
+const mockSocketConnect = vi.fn();
+const mockSocketDisconnect = vi.fn();
+const mockSocketSend = vi.fn().mockReturnValue(true);
+const mockSocketOnMessage = vi.fn().mockReturnValue(vi.fn());
+const mockSocketIsConnected = vi.fn().mockReturnValue(false);
+
+vi.mock("@/lib/socket", () => {
+  function MockSocketClient() {
+    return {
+      connect: mockSocketConnect,
+      disconnect: mockSocketDisconnect,
+      send: mockSocketSend,
+      onMessage: mockSocketOnMessage,
+      isConnected: mockSocketIsConnected,
+    };
+  }
+  return { SocketClient: MockSocketClient };
+});
+
+const MOCK_RECOGNITION_RESULT = {
+  id: "user-abc",
+  user_id: "user-abc",
+  matched_user_id: "user-abc",
+  confidence: 92.5,
+  created_at: new Date().toISOString(),
+  profile: {
+    user_id: "user-abc",
+    full_name: "Sarah Chen",
+    headline: "ML Engineer at OpenAI",
+    bio: "Passionate about AI",
+    location: "San Francisco",
+    company: "OpenAI",
+    major: "Computer Science",
+    graduation_year: 2021,
+    linkedin_url: "https://linkedin.com/in/sarachen",
+    photo_path: null,
+    experiences: [],
+    education: [],
+    profile_one_liner: "Building the future of AI",
+    profile_summary: null,
+  },
+};
+
+import RecognitionPage from "../page";
+
+describe("RecognitionPage", () => {
+  beforeEach(() => {
+    resetNavigationMocks();
+    resetSupabaseMocks();
+    mockGetMyEventConsent.mockClear();
+    mockGetCompatibility.mockClear();
+    mockSocketConnect.mockClear();
+    mockSocketDisconnect.mockClear();
+    mockSocketSend.mockClear();
+    mockSocketOnMessage.mockClear().mockReturnValue(vi.fn());
+    mockSocketIsConnected.mockClear().mockReturnValue(false);
+    mockSignOut.mockClear();
+    sessionStorage.clear();
+  });
+
+  it("shows loading spinner initially", () => {
+    mockSessionWith();
+    mockGetMyEventConsent.mockResolvedValue({
+      allow_profile_display: true,
+      allow_recognition: true,
+    });
+
+    render(<RecognitionPage />);
+
+    const spinners = document.querySelectorAll(".animate-spin");
+    expect(spinners.length).toBeGreaterThan(0);
+  });
+
+  it("renders Recognition Feed heading after loading", async () => {
+    mockSessionWith();
+    mockGetMyEventConsent.mockResolvedValue({
+      allow_profile_display: true,
+      allow_recognition: true,
+    });
+
+    render(<RecognitionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Recognition Feed")).toBeInTheDocument();
+    });
+  });
+
+  it("shows empty state when no results", async () => {
+    mockSessionWith();
+    mockGetMyEventConsent.mockResolvedValue({
+      allow_profile_display: true,
+      allow_recognition: true,
+    });
+
+    render(<RecognitionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Waiting for recognitions...")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Results appear here in real-time")).toBeInTheDocument();
+  });
+
+  it("renders recognition card when results are cached in sessionStorage", async () => {
+    sessionStorage.setItem(
+      "recognition_results_cache",
+      JSON.stringify([MOCK_RECOGNITION_RESULT]),
+    );
+    mockSessionWith();
+    mockGetMyEventConsent.mockResolvedValue({
+      allow_profile_display: true,
+      allow_recognition: true,
+    });
+    mockGetCompatibility.mockResolvedValue({
+      score: 0,
+      shared_companies: [],
+      shared_schools: [],
+      shared_fields: [],
+      conversation_starters: [],
+    });
+
+    render(<RecognitionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Sarah Chen")).toBeInTheDocument();
+    });
+  });
+
+  it("displays confidence score on recognition card", async () => {
+    sessionStorage.setItem(
+      "recognition_results_cache",
+      JSON.stringify([MOCK_RECOGNITION_RESULT]),
+    );
+    mockSessionWith();
+    mockGetMyEventConsent.mockResolvedValue({
+      allow_profile_display: true,
+      allow_recognition: true,
+    });
+    mockGetCompatibility.mockResolvedValue({
+      score: 0,
+      shared_companies: [],
+      shared_schools: [],
+      shared_fields: [],
+      conversation_starters: [],
+    });
+
+    render(<RecognitionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("93%")).toBeInTheDocument();
+    });
+  });
+
+  it("shows initials when no photo on recognition card", async () => {
+    sessionStorage.setItem(
+      "recognition_results_cache",
+      JSON.stringify([MOCK_RECOGNITION_RESULT]),
+    );
+    mockSessionWith();
+    mockGetMyEventConsent.mockResolvedValue({
+      allow_profile_display: true,
+      allow_recognition: true,
+    });
+    mockGetCompatibility.mockResolvedValue({
+      score: 0,
+      shared_companies: [],
+      shared_schools: [],
+      shared_fields: [],
+      conversation_starters: [],
+    });
+
+    render(<RecognitionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("SC")).toBeInTheDocument();
+    });
+  });
+
+  it("navigates to profile page when clicking a recognition card", async () => {
+    sessionStorage.setItem(
+      "recognition_results_cache",
+      JSON.stringify([MOCK_RECOGNITION_RESULT]),
+    );
+    mockSessionWith();
+    mockGetMyEventConsent.mockResolvedValue({
+      allow_profile_display: true,
+      allow_recognition: true,
+    });
+    mockGetCompatibility.mockResolvedValue({
+      score: 0,
+      shared_companies: [],
+      shared_schools: [],
+      shared_fields: [],
+      conversation_starters: [],
+    });
+
+    render(<RecognitionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Sarah Chen")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText("Sarah Chen"));
+
+    expect(mockPush).toHaveBeenCalledWith("/profile/user-abc");
+  });
+
+  it("caches profile to sessionStorage when clicking a card", async () => {
+    sessionStorage.setItem(
+      "recognition_results_cache",
+      JSON.stringify([MOCK_RECOGNITION_RESULT]),
+    );
+    mockSessionWith();
+    mockGetMyEventConsent.mockResolvedValue({
+      allow_profile_display: true,
+      allow_recognition: true,
+    });
+    mockGetCompatibility.mockResolvedValue({
+      score: 0,
+      shared_companies: [],
+      shared_schools: [],
+      shared_fields: [],
+      conversation_starters: [],
+    });
+
+    render(<RecognitionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Sarah Chen")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText("Sarah Chen"));
+
+    const cached = sessionStorage.getItem("profile_cache_user-abc");
+    expect(cached).not.toBeNull();
+    expect(JSON.parse(cached!).full_name).toBe("Sarah Chen");
+  });
+
+  it("renders camera mode toggle button", async () => {
+    mockSessionWith();
+    mockGetMyEventConsent.mockResolvedValue({
+      allow_profile_display: true,
+      allow_recognition: true,
+    });
+
+    render(<RecognitionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Glasses")).toBeInTheDocument();
+    });
+  });
+
+  it("switches to phone camera mode when toggle is clicked", async () => {
+    mockSessionWith();
+    mockGetMyEventConsent.mockResolvedValue({
+      allow_profile_display: true,
+      allow_recognition: true,
+    });
+
+    render(<RecognitionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Glasses")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText("Glasses"));
+
+    expect(screen.getByText("Phone")).toBeInTheDocument();
+  });
+
+  it("renders scan button", async () => {
+    mockSessionWith();
+    mockGetMyEventConsent.mockResolvedValue({
+      allow_profile_display: true,
+      allow_recognition: true,
+    });
+
+    render(<RecognitionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Scan")).toBeInTheDocument();
+    });
+  });
+
+  it("shows consent warning when consents are off", async () => {
+    vi.stubEnv("NEXT_PUBLIC_RECOGNITION_EVENT_ID", "evt-123");
+    mockSessionWith();
+    mockGetMyEventConsent.mockResolvedValue({
+      allow_profile_display: false,
+      allow_recognition: false,
+    });
+
+    render(<RecognitionPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "One or more event consents are off. You will not be able to recognize other attendees.",
+        ),
+      ).toBeInTheDocument();
+    });
+
+    vi.unstubAllEnvs();
+  });
+
+  it("does not show consent warning when consents are on", async () => {
+    vi.stubEnv("NEXT_PUBLIC_RECOGNITION_EVENT_ID", "evt-123");
+    mockSessionWith();
+    mockGetMyEventConsent.mockResolvedValue({
+      allow_profile_display: true,
+      allow_recognition: true,
+    });
+
+    render(<RecognitionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Waiting for recognitions...")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByText(
+        "One or more event consents are off. You will not be able to recognize other attendees.",
+      ),
+    ).not.toBeInTheDocument();
+
+    vi.unstubAllEnvs();
+  });
+
+  it("renders sign out button", async () => {
+    mockSessionWith();
+    mockGetMyEventConsent.mockResolvedValue({
+      allow_profile_display: true,
+      allow_recognition: true,
+    });
+
+    render(<RecognitionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Sign Out")).toBeInTheDocument();
+    });
+  });
+
+  it("calls sign out and redirects when sign out is clicked", async () => {
+    mockSessionWith();
+    mockSignOut.mockResolvedValue({ error: null });
+    mockGetMyEventConsent.mockResolvedValue({
+      allow_profile_display: true,
+      allow_recognition: true,
+    });
+
+    render(<RecognitionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Sign Out")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText("Sign Out"));
+
+    await waitFor(() => {
+      expect(mockSignOut).toHaveBeenCalled();
+      expect(mockPush).toHaveBeenCalledWith("/");
+    });
+  });
+
+  it("connects socket with access token on init", async () => {
+    mockSessionWith("my-test-token");
+    mockGetMyEventConsent.mockResolvedValue({
+      allow_profile_display: true,
+      allow_recognition: true,
+    });
+
+    render(<RecognitionPage />);
+
+    await waitFor(() => {
+      expect(mockSocketConnect).toHaveBeenCalledWith("my-test-token");
+    });
+  });
+
+  it("does not connect socket when no session", async () => {
+    mockNoSession();
+
+    render(<RecognitionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Waiting for recognitions...")).toBeInTheDocument();
+    });
+
+    expect(mockSocketConnect).not.toHaveBeenCalled();
+  });
+
+  it("displays compatibility score when available", async () => {
+    const resultWithCompat = {
+      ...MOCK_RECOGNITION_RESULT,
+      compatibility: {
+        score: 78,
+        shared_companies: [],
+        shared_schools: ["Purdue University"],
+        shared_fields: [],
+        conversation_starters: ["Ask about their Purdue experience"],
+      },
+    };
+    sessionStorage.setItem(
+      "recognition_results_cache",
+      JSON.stringify([resultWithCompat]),
+    );
+    mockSessionWith();
+    mockGetMyEventConsent.mockResolvedValue({
+      allow_profile_display: true,
+      allow_recognition: true,
+    });
+    mockGetCompatibility.mockResolvedValue(resultWithCompat.compatibility);
+
+    render(<RecognitionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("78% match")).toBeInTheDocument();
+    });
+  });
+
+  it("displays shared schools from compatibility data", async () => {
+    const resultWithCompat = {
+      ...MOCK_RECOGNITION_RESULT,
+      compatibility: {
+        score: 65,
+        shared_companies: [],
+        shared_schools: ["Purdue University"],
+        shared_fields: ["Machine Learning"],
+        conversation_starters: [],
+      },
+    };
+    sessionStorage.setItem(
+      "recognition_results_cache",
+      JSON.stringify([resultWithCompat]),
+    );
+    mockSessionWith();
+    mockGetMyEventConsent.mockResolvedValue({
+      allow_profile_display: true,
+      allow_recognition: true,
+    });
+    mockGetCompatibility.mockResolvedValue(resultWithCompat.compatibility);
+
+    render(<RecognitionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Purdue University/)).toBeInTheDocument();
+    });
+  });
+
+  it("displays conversation starter when available", async () => {
+    const resultWithStarter = {
+      ...MOCK_RECOGNITION_RESULT,
+      compatibility: {
+        score: 50,
+        shared_companies: [],
+        shared_schools: [],
+        shared_fields: [],
+        conversation_starters: ["Ask about their AI research"],
+      },
+    };
+    sessionStorage.setItem(
+      "recognition_results_cache",
+      JSON.stringify([resultWithStarter]),
+    );
+    mockSessionWith();
+    mockGetMyEventConsent.mockResolvedValue({
+      allow_profile_display: true,
+      allow_recognition: true,
+    });
+    mockGetCompatibility.mockResolvedValue(resultWithStarter.compatibility);
+
+    render(<RecognitionPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Ask about their AI research/)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/__tests__/bottom-tab-bar.test.tsx
+++ b/frontend/src/components/__tests__/bottom-tab-bar.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  mockPush,
+  mockPathname,
+  resetNavigationMocks,
+} from "@/test/mocks/next-navigation";
+import { BottomTabBar } from "../bottom-tab-bar";
+
+describe("BottomTabBar", () => {
+  beforeEach(() => {
+    resetNavigationMocks();
+  });
+
+  it("renders all tab labels", () => {
+    render(<BottomTabBar />);
+    expect(screen.getByText("Dashboard")).toBeInTheDocument();
+    expect(screen.getByText("Profile")).toBeInTheDocument();
+  });
+
+  it("highlights the active tab based on pathname", () => {
+    mockPathname.mockReturnValue("/dashboard");
+    const { container } = render(<BottomTabBar />);
+    const buttons = container.querySelectorAll("button");
+    const dashboardBtn = buttons[0];
+    const profileBtn = buttons[buttons.length - 1];
+    expect(dashboardBtn.style.color).toContain("0.95");
+    expect(profileBtn.style.color).toContain("0.3");
+  });
+
+  it("highlights Profile tab when on /profile path", () => {
+    mockPathname.mockReturnValue("/profile");
+    const { container } = render(<BottomTabBar />);
+    const buttons = container.querySelectorAll("button");
+    const profileBtn = buttons[buttons.length - 1];
+    expect(profileBtn.style.color).toContain("0.95");
+  });
+
+  it("highlights tab for nested paths", () => {
+    mockPathname.mockReturnValue("/dashboard/some-sub-page");
+    const { container } = render(<BottomTabBar />);
+    const buttons = container.querySelectorAll("button");
+    const dashboardBtn = buttons[0];
+    expect(dashboardBtn.style.color).toContain("0.95");
+  });
+
+  it("navigates when a tab is clicked", async () => {
+    render(<BottomTabBar />);
+    await userEvent.click(screen.getByText("Profile"));
+    expect(mockPush).toHaveBeenCalledWith("/profile");
+  });
+
+  it("navigates to /dashboard when Dashboard tab is clicked", async () => {
+    render(<BottomTabBar />);
+    await userEvent.click(screen.getByText("Dashboard"));
+    expect(mockPush).toHaveBeenCalledWith("/dashboard");
+  });
+});

--- a/frontend/src/components/__tests__/confirmation-dialog.test.tsx
+++ b/frontend/src/components/__tests__/confirmation-dialog.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { ConfirmationDialog } from "../confirmation-dialog";
+
+describe("ConfirmationDialog", () => {
+  const defaultProps = {
+    open: true,
+    title: "Delete item?",
+    message: "This action cannot be undone.",
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+  };
+
+  it("renders nothing when open is false", () => {
+    const { container } = render(
+      <ConfirmationDialog {...defaultProps} open={false} />
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders title and message when open", () => {
+    render(<ConfirmationDialog {...defaultProps} />);
+    expect(screen.getByText("Delete item?")).toBeInTheDocument();
+    expect(screen.getByText("This action cannot be undone.")).toBeInTheDocument();
+  });
+
+  it("uses default button labels", () => {
+    render(<ConfirmationDialog {...defaultProps} />);
+    expect(screen.getByText("Cancel")).toBeInTheDocument();
+    expect(screen.getByText("Confirm")).toBeInTheDocument();
+  });
+
+  it("uses custom button labels", () => {
+    render(
+      <ConfirmationDialog
+        {...defaultProps}
+        confirmLabel="Yes, delete"
+        cancelLabel="Go back"
+      />
+    );
+    expect(screen.getByText("Go back")).toBeInTheDocument();
+    expect(screen.getByText("Yes, delete")).toBeInTheDocument();
+  });
+
+  it("calls onConfirm when confirm button is clicked", async () => {
+    const onConfirm = vi.fn();
+    render(<ConfirmationDialog {...defaultProps} onConfirm={onConfirm} />);
+    await userEvent.click(screen.getByText("Confirm"));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onCancel when cancel button is clicked", async () => {
+    const onCancel = vi.fn();
+    render(<ConfirmationDialog {...defaultProps} onCancel={onCancel} />);
+    await userEvent.click(screen.getByText("Cancel"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onCancel when backdrop is clicked", async () => {
+    const onCancel = vi.fn();
+    render(<ConfirmationDialog {...defaultProps} onCancel={onCancel} />);
+    await userEvent.click(screen.getByLabelText("Close confirmation dialog"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables confirm button when confirmDisabled is true", () => {
+    render(<ConfirmationDialog {...defaultProps} confirmDisabled />);
+    const confirmBtn = screen.getByText("Confirm");
+    expect(confirmBtn).toBeDisabled();
+  });
+
+  it("hides cancel button when hideCancel is true", () => {
+    render(<ConfirmationDialog {...defaultProps} hideCancel />);
+    expect(screen.queryByText("Cancel")).not.toBeInTheDocument();
+    expect(screen.getByText("Confirm")).toBeInTheDocument();
+  });
+
+  it("renders confirm icon when provided", () => {
+    render(
+      <ConfirmationDialog
+        {...defaultProps}
+        confirmIcon={<span data-testid="icon">X</span>}
+      />
+    );
+    expect(screen.getByTestId("icon")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/login-content.test.tsx
+++ b/frontend/src/components/__tests__/login-content.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  mockPush,
+  mockReplace,
+  mockRefresh,
+  resetNavigationMocks,
+} from "@/test/mocks/next-navigation";
+import {
+  mockSignInWithPassword,
+  mockGetSession,
+  mockSignInWithOAuth,
+  resetSupabaseMocks,
+} from "@/test/mocks/supabase";
+import { LoginContent } from "../login-content";
+
+vi.mock("@/lib/api", () => {
+  const getProfile = vi.fn();
+  return {
+    api: { setToken: vi.fn(), getProfile },
+    ApiError: class extends Error {
+      status: number;
+      constructor(status: number, message: string) {
+        super(message);
+        this.status = status;
+      }
+    },
+  };
+});
+
+describe("LoginContent", () => {
+  const defaultProps = {
+    onBack: vi.fn(),
+    onGoSignup: vi.fn(),
+  };
+
+  beforeEach(() => {
+    resetNavigationMocks();
+    resetSupabaseMocks();
+    defaultProps.onBack.mockClear();
+    defaultProps.onGoSignup.mockClear();
+  });
+
+  it("renders email and password fields", () => {
+    render(<LoginContent {...defaultProps} />);
+    expect(screen.getByPlaceholderText("you@example.com")).toBeInTheDocument();
+  });
+
+  it("calls onBack when back button is clicked", async () => {
+    render(<LoginContent {...defaultProps} />);
+    const backButtons = screen.getAllByRole("button");
+    const backBtn = backButtons.find((btn) =>
+      btn.querySelector(".lucide-chevron-left")
+    );
+    if (backBtn) await userEvent.click(backBtn);
+    expect(defaultProps.onBack).toHaveBeenCalled();
+  });
+
+  it("shows Sign In button text", () => {
+    render(<LoginContent {...defaultProps} />);
+    expect(screen.getByText("Sign In")).toBeInTheDocument();
+  });
+
+  it("shows Create an account link", () => {
+    render(<LoginContent {...defaultProps} />);
+    expect(screen.getByText("Create an account")).toBeInTheDocument();
+  });
+
+  it("calls onGoSignup when Create an account is clicked", async () => {
+    render(<LoginContent {...defaultProps} />);
+    await userEvent.click(screen.getByText("Create an account"));
+    expect(defaultProps.onGoSignup).toHaveBeenCalled();
+  });
+
+  it("shows error message when login fails", async () => {
+    mockSignInWithPassword.mockResolvedValue({
+      error: { message: "Invalid credentials" },
+    });
+
+    render(<LoginContent {...defaultProps} />);
+
+    const emailInput = screen.getByPlaceholderText("you@example.com");
+    await userEvent.type(emailInput, "test@example.com");
+
+    const advBtn = screen
+      .getAllByRole("button")
+      .find((btn) => btn.querySelector(".lucide-chevron-right"));
+    if (advBtn) await userEvent.click(advBtn);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Your password")).toBeInTheDocument();
+    });
+
+    const pwdInput = screen.getByPlaceholderText("Your password");
+    await userEvent.type(pwdInput, "password123");
+
+    await userEvent.click(screen.getByText("Sign In"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Invalid credentials")).toBeInTheDocument();
+    });
+  });
+
+  it("navigates to dashboard on successful login with profile", async () => {
+    const { api } = await import("@/lib/api");
+
+    mockSignInWithPassword.mockResolvedValue({ error: null });
+    mockGetSession.mockResolvedValue({
+      data: {
+        session: {
+          access_token: "token-123",
+          user: { id: "u1", email: "test@example.com" },
+        },
+      },
+    });
+    (api.getProfile as ReturnType<typeof vi.fn>).mockResolvedValue({
+      user_id: "u1",
+      full_name: "Test",
+    });
+
+    render(<LoginContent {...defaultProps} />);
+
+    const emailInput = screen.getByPlaceholderText("you@example.com");
+    await userEvent.type(emailInput, "test@example.com");
+
+    const advanceBtns = screen.getAllByRole("button");
+    const advBtn = advanceBtns.find((btn) =>
+      btn.querySelector(".lucide-chevron-right")
+    );
+    if (advBtn) await userEvent.click(advBtn);
+
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText("Your password")).toBeInTheDocument();
+    });
+
+    await userEvent.type(
+      screen.getByPlaceholderText("Your password"),
+      "password123"
+    );
+
+    await userEvent.click(screen.getByText("Sign In"));
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/dashboard");
+    });
+  });
+
+  it("has Continue with Google button", () => {
+    render(<LoginContent {...defaultProps} />);
+    expect(screen.getByText("Continue with Google")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/modal-bottom-sheet.test.tsx
+++ b/frontend/src/components/__tests__/modal-bottom-sheet.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { ModalBottomSheet } from "../modal-bottom-sheet";
+
+describe("ModalBottomSheet", () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    children: <div>Sheet content</div>,
+  };
+
+  it("renders children when open", () => {
+    render(<ModalBottomSheet {...defaultProps} />);
+    expect(screen.getByText("Sheet content")).toBeInTheDocument();
+  });
+
+  it("has aria-hidden=true when closed", () => {
+    const { container } = render(
+      <ModalBottomSheet {...defaultProps} isOpen={false} />
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("has aria-hidden=false when open", () => {
+    const { container } = render(<ModalBottomSheet {...defaultProps} />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.getAttribute("aria-hidden")).toBe("false");
+  });
+
+  it("renders title and close button when title is provided", () => {
+    render(<ModalBottomSheet {...defaultProps} title="Settings" />);
+    expect(screen.getByText("Settings")).toBeInTheDocument();
+    expect(screen.getByText("Close")).toBeInTheDocument();
+  });
+
+  it("does not render title area when no title", () => {
+    render(<ModalBottomSheet {...defaultProps} />);
+    expect(screen.queryByText("Close")).not.toBeInTheDocument();
+  });
+
+  it("calls onClose when backdrop is clicked", async () => {
+    const onClose = vi.fn();
+    render(<ModalBottomSheet {...defaultProps} onClose={onClose} />);
+    await userEvent.click(screen.getByLabelText("Close bottom sheet"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when close button is clicked", async () => {
+    const onClose = vi.fn();
+    render(
+      <ModalBottomSheet {...defaultProps} onClose={onClose} title="Test" />
+    );
+    await userEvent.click(screen.getByText("Close"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("locks body scroll when open", () => {
+    render(<ModalBottomSheet {...defaultProps} />);
+    expect(document.body.style.overflow).toBe("hidden");
+  });
+
+  it("restores body scroll when closed", () => {
+    const { rerender } = render(<ModalBottomSheet {...defaultProps} />);
+    expect(document.body.style.overflow).toBe("hidden");
+    rerender(<ModalBottomSheet {...defaultProps} isOpen={false} />);
+    expect(document.body.style.overflow).not.toBe("hidden");
+  });
+
+  it("disables pointer events when closed", () => {
+    const { container } = render(
+      <ModalBottomSheet {...defaultProps} isOpen={false} />
+    );
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.style.pointerEvents).toBe("none");
+  });
+});

--- a/frontend/src/components/__tests__/signup-content.test.tsx
+++ b/frontend/src/components/__tests__/signup-content.test.tsx
@@ -1,0 +1,168 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  mockReplace,
+  resetNavigationMocks,
+} from "@/test/mocks/next-navigation";
+import {
+  mockSignUp,
+  resetSupabaseMocks,
+} from "@/test/mocks/supabase";
+import { SignupContent } from "../signup-content";
+
+describe("SignupContent", () => {
+  const defaultProps = {
+    onBack: vi.fn(),
+    onGoLogin: vi.fn(),
+  };
+
+  beforeEach(() => {
+    resetNavigationMocks();
+    resetSupabaseMocks();
+    defaultProps.onBack.mockClear();
+    defaultProps.onGoLogin.mockClear();
+  });
+
+  it("renders the full name field first", () => {
+    render(<SignupContent {...defaultProps} />);
+    expect(screen.getByPlaceholderText("Jane Smith")).toBeInTheDocument();
+  });
+
+  it("shows Create Account button text", () => {
+    render(<SignupContent {...defaultProps} />);
+    expect(screen.getByText("Create Account")).toBeInTheDocument();
+  });
+
+  it("shows Sign in link", () => {
+    render(<SignupContent {...defaultProps} />);
+    expect(screen.getByText("Sign in")).toBeInTheDocument();
+  });
+
+  it("calls onGoLogin when Sign in is clicked", async () => {
+    render(<SignupContent {...defaultProps} />);
+    await userEvent.click(screen.getByText("Sign in"));
+    expect(defaultProps.onGoLogin).toHaveBeenCalled();
+  });
+
+  it("calls onBack when back button is clicked", async () => {
+    render(<SignupContent {...defaultProps} />);
+    const backButtons = screen.getAllByRole("button");
+    const backBtn = backButtons.find((btn) =>
+      btn.querySelector(".lucide-chevron-left")
+    );
+    if (backBtn) await userEvent.click(backBtn);
+    expect(defaultProps.onBack).toHaveBeenCalled();
+  });
+
+  it("shows error message when signup fails", async () => {
+    mockSignUp.mockResolvedValue({
+      error: { message: "Email already taken" },
+    });
+
+    render(<SignupContent {...defaultProps} />);
+
+    const nameInput = screen.getByPlaceholderText("Jane Smith");
+    await userEvent.type(nameInput, "Test User");
+
+    const advanceBtns = screen.getAllByRole("button");
+    const advBtn = advanceBtns.find((btn) =>
+      btn.querySelector(".lucide-chevron-right")
+    );
+    if (advBtn) await userEvent.click(advBtn);
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText("you@example.com")
+      ).toBeInTheDocument();
+    });
+
+    await userEvent.type(
+      screen.getByPlaceholderText("you@example.com"),
+      "test@example.com"
+    );
+
+    const advBtns2 = screen.getAllByRole("button");
+    const advBtn2 = advBtns2.find((btn) =>
+      btn.querySelector(".lucide-chevron-right")
+    );
+    if (advBtn2) await userEvent.click(advBtn2);
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText("At least 6 characters")
+      ).toBeInTheDocument();
+    });
+
+    await userEvent.type(
+      screen.getByPlaceholderText("At least 6 characters"),
+      "password123"
+    );
+
+    await userEvent.click(screen.getByText("Create Account"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Email already taken")).toBeInTheDocument();
+    });
+  });
+
+  it("navigates to onboarding on successful signup", async () => {
+    mockSignUp.mockResolvedValue({ error: null });
+
+    render(<SignupContent {...defaultProps} />);
+
+    await userEvent.type(
+      screen.getByPlaceholderText("Jane Smith"),
+      "Test User"
+    );
+
+    const advBtn = screen
+      .getAllByRole("button")
+      .find((btn) => btn.querySelector(".lucide-chevron-right"));
+    if (advBtn) await userEvent.click(advBtn);
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText("you@example.com")
+      ).toBeInTheDocument();
+    });
+
+    await userEvent.type(
+      screen.getByPlaceholderText("you@example.com"),
+      "test@example.com"
+    );
+
+    const advBtn2 = screen
+      .getAllByRole("button")
+      .find((btn) => btn.querySelector(".lucide-chevron-right"));
+    if (advBtn2) await userEvent.click(advBtn2);
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText("At least 6 characters")
+      ).toBeInTheDocument();
+    });
+
+    await userEvent.type(
+      screen.getByPlaceholderText("At least 6 characters"),
+      "password123"
+    );
+
+    await userEvent.click(screen.getByText("Create Account"));
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("/onboarding");
+    });
+  });
+
+  it("has Continue with Google button", () => {
+    render(<SignupContent {...defaultProps} />);
+    expect(screen.getByText("Continue with Google")).toBeInTheDocument();
+  });
+
+  it("shows field labels for all three fields", () => {
+    render(<SignupContent {...defaultProps} />);
+    expect(screen.getAllByText("Full Name").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByPlaceholderText("Jane Smith")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/lib/__tests__/api.test.ts
+++ b/frontend/src/lib/__tests__/api.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const originalFetch = globalThis.fetch;
+
+let ApiClient: new () => { setToken: (t: string) => void; getProfile: () => Promise<unknown> };
+let ApiError: new (status: number, message: string) => Error & { status: number };
+let isApiErrorWithStatus: (error: unknown, status: number) => boolean;
+let apiInstance: InstanceType<typeof ApiClient>;
+
+describe("ApiClient", () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(async () => {
+    vi.resetModules();
+    globalThis.fetch = mockFetch;
+    mockFetch.mockClear();
+
+    const mod = await import("../api");
+    ApiError = mod.ApiError;
+    isApiErrorWithStatus = mod.isApiErrorWithStatus;
+    apiInstance = mod.api;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("includes Authorization header when token is set", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ user_id: "u1" }),
+    });
+
+    apiInstance.setToken("my-token");
+    await apiInstance.getProfile();
+
+    const [, init] = mockFetch.mock.calls[0];
+    expect(init.headers.Authorization).toBe("Bearer my-token");
+  });
+
+  it("includes Content-Type and ngrok headers", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    });
+
+    apiInstance.setToken("token");
+    await apiInstance.getProfile();
+
+    const [, init] = mockFetch.mock.calls[0];
+    expect(init.headers["Content-Type"]).toBe("application/json");
+    expect(init.headers["ngrok-skip-browser-warning"]).toBe("true");
+  });
+
+  it("throws ApiError with string detail on non-ok response", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+      json: () => Promise.resolve({ detail: "Profile not found" }),
+    });
+
+    apiInstance.setToken("token");
+    await expect(apiInstance.getProfile()).rejects.toThrow("Profile not found");
+  });
+
+  it("throws ApiError with joined array detail", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 422,
+      statusText: "Unprocessable Entity",
+      json: () =>
+        Promise.resolve({
+          detail: [
+            { msg: "field required", loc: ["body", "name"] },
+            { msg: "invalid email", loc: ["body", "email"] },
+          ],
+        }),
+    });
+
+    apiInstance.setToken("token");
+    await expect(apiInstance.getProfile()).rejects.toThrow(
+      "field required; invalid email"
+    );
+  });
+
+  it("throws ApiError with fallback message when detail is not string/array", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      json: () => Promise.resolve({ detail: { nested: true } }),
+    });
+
+    apiInstance.setToken("token");
+    await expect(apiInstance.getProfile()).rejects.toThrow(
+      "Request failed: 500 Internal Server Error"
+    );
+  });
+
+  it("throws ApiError with fallback when response body is not JSON", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 502,
+      statusText: "Bad Gateway",
+      json: () => Promise.reject(new Error("not json")),
+    });
+
+    apiInstance.setToken("token");
+    await expect(apiInstance.getProfile()).rejects.toThrow(
+      "Request failed: 502 Bad Gateway"
+    );
+  });
+
+  it("returns undefined for 204 responses", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 204,
+      json: () => Promise.reject(new Error("no body")),
+    });
+
+    apiInstance.setToken("token");
+    const result = await (apiInstance as unknown as { getProfile: () => Promise<unknown> }).getProfile();
+    expect(result).toBeUndefined();
+  });
+
+  it("constructs URL from API_URL env + path", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    });
+
+    apiInstance.setToken("token");
+    await apiInstance.getProfile();
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain("/api/v1/profiles/me");
+  });
+});
+
+describe("ApiError", () => {
+  it("has status and message properties", async () => {
+    const mod = await import("../api");
+    const error = new mod.ApiError(403, "Forbidden");
+    expect(error.status).toBe(403);
+    expect(error.message).toBe("Forbidden");
+    expect(error.name).toBe("ApiError");
+    expect(error).toBeInstanceOf(Error);
+  });
+});
+
+describe("isApiErrorWithStatus", () => {
+  it("returns true for matching ApiError", async () => {
+    const mod = await import("../api");
+    const error = new mod.ApiError(404, "Not found");
+    expect(mod.isApiErrorWithStatus(error, 404)).toBe(true);
+  });
+
+  it("returns false for wrong status", async () => {
+    const mod = await import("../api");
+    const error = new mod.ApiError(404, "Not found");
+    expect(mod.isApiErrorWithStatus(error, 500)).toBe(false);
+  });
+
+  it("returns false for non-ApiError", async () => {
+    const mod = await import("../api");
+    const error = new Error("Regular error");
+    expect(mod.isApiErrorWithStatus(error, 500)).toBe(false);
+  });
+
+  it("returns false for null/undefined", async () => {
+    const mod = await import("../api");
+    expect(mod.isApiErrorWithStatus(null, 500)).toBe(false);
+    expect(mod.isApiErrorWithStatus(undefined, 500)).toBe(false);
+  });
+});

--- a/frontend/src/lib/__tests__/consent-cache.test.ts
+++ b/frontend/src/lib/__tests__/consent-cache.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { getCachedEventConsent, setCachedEventConsent } from "../consent-cache";
+import type { ConsentResponse } from "../api";
+
+const CACHE_KEY = "event_consent_cache_v1";
+
+function makeConsent(overrides: Partial<ConsentResponse> = {}): ConsentResponse {
+  return {
+    event_id: "evt-1",
+    user_id: "user-1",
+    allow_profile_display: true,
+    allow_recognition: false,
+    consented_at: "2026-01-01T00:00:00Z",
+    revoked_at: null,
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("consent-cache", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("returns null when no cache exists", () => {
+    expect(getCachedEventConsent("evt-1")).toBeNull();
+  });
+
+  it("stores and retrieves a consent", () => {
+    const consent = makeConsent();
+    setCachedEventConsent("evt-1", consent);
+    const cached = getCachedEventConsent("evt-1");
+    expect(cached).toEqual(consent);
+  });
+
+  it("returns null for a different event ID", () => {
+    setCachedEventConsent("evt-1", makeConsent());
+    expect(getCachedEventConsent("evt-2")).toBeNull();
+  });
+
+  it("overwrites consent for the same event", () => {
+    setCachedEventConsent("evt-1", makeConsent({ allow_recognition: false }));
+    setCachedEventConsent("evt-1", makeConsent({ allow_recognition: true }));
+    const cached = getCachedEventConsent("evt-1");
+    expect(cached?.allow_recognition).toBe(true);
+  });
+
+  it("stores multiple events independently", () => {
+    const consent1 = makeConsent({ event_id: "evt-1" });
+    const consent2 = makeConsent({
+      event_id: "evt-2",
+      allow_recognition: true,
+    });
+    setCachedEventConsent("evt-1", consent1);
+    setCachedEventConsent("evt-2", consent2);
+
+    expect(getCachedEventConsent("evt-1")).toEqual(consent1);
+    expect(getCachedEventConsent("evt-2")).toEqual(consent2);
+  });
+
+  it("handles corrupted cache gracefully", () => {
+    sessionStorage.setItem(CACHE_KEY, "not-valid-json{{{");
+    expect(getCachedEventConsent("evt-1")).toBeNull();
+  });
+
+  it("handles empty string in cache gracefully", () => {
+    sessionStorage.setItem(CACHE_KEY, "");
+    expect(getCachedEventConsent("evt-1")).toBeNull();
+  });
+});

--- a/frontend/src/lib/__tests__/onboarding.test.ts
+++ b/frontend/src/lib/__tests__/onboarding.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  saveMissingSteps,
+  getFirstMissingRoute,
+  getNextRoute,
+} from "../onboarding";
+
+describe("onboarding helpers", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  describe("getFirstMissingRoute", () => {
+    it("returns /dashboard when no fields are missing", () => {
+      expect(getFirstMissingRoute([])).toBe("/dashboard");
+    });
+
+    it("returns the route for the first missing field in step order", () => {
+      expect(getFirstMissingRoute(["bio", "name"])).toBe("/onboarding/name");
+    });
+
+    it("returns /onboarding/photo for profile_pic", () => {
+      expect(getFirstMissingRoute(["profile_pic"])).toBe("/onboarding/photo");
+    });
+
+    it("returns /onboarding/experience for experiences", () => {
+      expect(getFirstMissingRoute(["experiences"])).toBe(
+        "/onboarding/experience"
+      );
+    });
+
+    it("returns /onboarding/education for education", () => {
+      expect(getFirstMissingRoute(["education"])).toBe(
+        "/onboarding/education"
+      );
+    });
+
+    it("returns /onboarding/location for location", () => {
+      expect(getFirstMissingRoute(["location"])).toBe("/onboarding/location");
+    });
+
+    it("returns /onboarding/bio for bio", () => {
+      expect(getFirstMissingRoute(["bio"])).toBe("/onboarding/bio");
+    });
+
+    it("respects step order: name before photo before location", () => {
+      expect(getFirstMissingRoute(["location", "profile_pic", "name"])).toBe(
+        "/onboarding/name"
+      );
+    });
+
+    it("ignores unknown backend fields", () => {
+      expect(getFirstMissingRoute(["unknown_field"])).toBe("/dashboard");
+    });
+
+    it("skips unknown fields and returns first known", () => {
+      expect(getFirstMissingRoute(["unknown", "bio"])).toBe("/onboarding/bio");
+    });
+  });
+
+  describe("saveMissingSteps", () => {
+    it("persists steps to localStorage", () => {
+      saveMissingSteps(["name", "bio"]);
+      const stored = JSON.parse(localStorage.getItem("onboarding_missing_steps")!);
+      expect(stored).toEqual(["name", "bio"]);
+    });
+
+    it("filters out unknown fields", () => {
+      saveMissingSteps(["name", "unknown_field", "bio"]);
+      const stored = JSON.parse(localStorage.getItem("onboarding_missing_steps")!);
+      expect(stored).toEqual(["name", "bio"]);
+    });
+
+    it("maps backend field names to step names", () => {
+      saveMissingSteps(["profile_pic", "experiences"]);
+      const stored = JSON.parse(localStorage.getItem("onboarding_missing_steps")!);
+      expect(stored).toEqual(["photo", "experience"]);
+    });
+  });
+
+  describe("getNextRoute", () => {
+    it("returns /dashboard when no steps are saved (all steps fallback) and current is last", () => {
+      expect(getNextRoute("education")).toBe("/dashboard");
+    });
+
+    it("returns next missing step after current", () => {
+      saveMissingSteps(["name", "bio", "education"]);
+      expect(getNextRoute("name")).toBe("/onboarding/bio");
+    });
+
+    it("returns /dashboard when current step is last missing step", () => {
+      saveMissingSteps(["name", "bio"]);
+      expect(getNextRoute("bio")).toBe("/dashboard");
+    });
+
+    it("skips completed steps", () => {
+      saveMissingSteps(["name", "education"]);
+      expect(getNextRoute("name")).toBe("/onboarding/education");
+    });
+
+    it("returns /dashboard when there are no missing steps", () => {
+      saveMissingSteps([]);
+      expect(getNextRoute("name")).toBe("/dashboard");
+    });
+
+    it("returns first available step after current even if not adjacent", () => {
+      saveMissingSteps(["name", "experiences"]);
+      expect(getNextRoute("name")).toBe("/onboarding/experience");
+    });
+
+    it("falls back to showing all steps when localStorage is empty", () => {
+      expect(getNextRoute("name")).toBe("/onboarding/photo");
+    });
+  });
+});

--- a/frontend/src/lib/__tests__/socket.test.ts
+++ b/frontend/src/lib/__tests__/socket.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { SocketClient } from "../socket";
+
+class MockWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  readonly CONNECTING = 0;
+  readonly OPEN = 1;
+  readonly CLOSING = 2;
+  readonly CLOSED = 3;
+
+  url: string;
+  readyState: number = MockWebSocket.CONNECTING;
+  onopen: ((ev: Event) => void) | null = null;
+  onclose: ((ev: CloseEvent) => void) | null = null;
+  onmessage: ((ev: MessageEvent) => void) | null = null;
+  onerror: ((ev: Event) => void) | null = null;
+  send = vi.fn();
+  close = vi.fn();
+  protocol = "";
+  bufferedAmount = 0;
+  extensions = "";
+  binaryType: BinaryType = "blob";
+  addEventListener = vi.fn();
+  removeEventListener = vi.fn();
+  dispatchEvent = vi.fn().mockReturnValue(true);
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+  }
+
+  static instances: MockWebSocket[] = [];
+  static reset() {
+    MockWebSocket.instances = [];
+  }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.(new Event("open"));
+  }
+
+  simulateMessage(data: string) {
+    this.onmessage?.(new MessageEvent("message", { data }));
+  }
+
+  simulateClose(code = 1000, wasClean = true) {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.({ code, wasClean, reason: "" } as CloseEvent);
+  }
+
+  simulateError() {
+    this.onerror?.(new Event("error"));
+  }
+}
+
+describe("SocketClient", () => {
+  let client: SocketClient;
+  const originalWS = globalThis.WebSocket;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    MockWebSocket.reset();
+    globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
+    client = new SocketClient("ws://test-server:3001");
+  });
+
+  afterEach(() => {
+    client.disconnect();
+    globalThis.WebSocket = originalWS;
+    vi.useRealTimers();
+  });
+
+  it("creates a WebSocket connection on connect", () => {
+    client.connect();
+    expect(MockWebSocket.instances).toHaveLength(1);
+    expect(MockWebSocket.instances[0].url).toContain("ws://test-server:3001");
+  });
+
+  it("includes token in connection URL when provided", () => {
+    client.connect("my-auth-token");
+    expect(MockWebSocket.instances[0].url).toContain("token=my-auth-token");
+  });
+
+  it("does not include token query param when no token", () => {
+    client.connect();
+    expect(MockWebSocket.instances[0].url).not.toContain("token=");
+  });
+
+  it("does not create duplicate connections when already connected", () => {
+    client.connect();
+    MockWebSocket.instances[0].simulateOpen();
+    client.connect();
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+
+  it("does not create duplicate connections when still connecting", () => {
+    client.connect();
+    client.connect();
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+
+  it("reports isConnected correctly", () => {
+    expect(client.isConnected()).toBe(false);
+    client.connect();
+    expect(client.isConnected()).toBe(false);
+    MockWebSocket.instances[0].simulateOpen();
+    expect(client.isConnected()).toBe(true);
+  });
+
+  it("parses and dispatches valid messages to handlers", () => {
+    const handler = vi.fn();
+    client.onMessage(handler);
+    client.connect();
+    MockWebSocket.instances[0].simulateOpen();
+
+    const msg = JSON.stringify({
+      type: "connected",
+      payload: { clientId: "c1" },
+    });
+    MockWebSocket.instances[0].simulateMessage(msg);
+
+    expect(handler).toHaveBeenCalledWith({
+      type: "connected",
+      payload: { clientId: "c1" },
+    });
+  });
+
+  it("ignores invalid JSON messages", () => {
+    const handler = vi.fn();
+    client.onMessage(handler);
+    client.connect();
+    MockWebSocket.instances[0].simulateOpen();
+    MockWebSocket.instances[0].simulateMessage("not-json{{{");
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("ignores messages without a type field", () => {
+    const handler = vi.fn();
+    client.onMessage(handler);
+    client.connect();
+    MockWebSocket.instances[0].simulateOpen();
+    MockWebSocket.instances[0].simulateMessage(JSON.stringify({ payload: {} }));
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("ignores messages with empty type", () => {
+    const handler = vi.fn();
+    client.onMessage(handler);
+    client.connect();
+    MockWebSocket.instances[0].simulateOpen();
+    MockWebSocket.instances[0].simulateMessage(
+      JSON.stringify({ type: "", payload: {} })
+    );
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("allows removing a message handler", () => {
+    const handler = vi.fn();
+    const unsub = client.onMessage(handler);
+    unsub();
+    client.connect();
+    MockWebSocket.instances[0].simulateOpen();
+    MockWebSocket.instances[0].simulateMessage(
+      JSON.stringify({ type: "ack", payload: { receivedType: "test" } })
+    );
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("send returns true when connected", () => {
+    client.connect();
+    MockWebSocket.instances[0].simulateOpen();
+    const result = client.send({
+      type: "start_recognition",
+      payload: { event_id: "e1" },
+    });
+    expect(result).toBe(true);
+    expect(MockWebSocket.instances[0].send).toHaveBeenCalledWith(
+      JSON.stringify({
+        type: "start_recognition",
+        payload: { event_id: "e1" },
+      })
+    );
+  });
+
+  it("send returns false when not connected", () => {
+    const result = client.send({ type: "stop_recognition" });
+    expect(result).toBe(false);
+  });
+
+  it("send returns false when socket is connecting", () => {
+    client.connect();
+    const result = client.send({ type: "stop_recognition" });
+    expect(result).toBe(false);
+  });
+
+  it("closes the WebSocket on disconnect", () => {
+    client.connect();
+    MockWebSocket.instances[0].simulateOpen();
+    client.disconnect();
+    expect(MockWebSocket.instances[0].close).toHaveBeenCalled();
+  });
+
+  it("schedules reconnection after unclean close", () => {
+    client.connect();
+    MockWebSocket.instances[0].simulateOpen();
+    MockWebSocket.instances[0].simulateClose(1006, false);
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+    vi.advanceTimersByTime(2000);
+    expect(MockWebSocket.instances).toHaveLength(2);
+  });
+
+  it("does not reconnect after explicit disconnect", () => {
+    client.connect();
+    MockWebSocket.instances[0].simulateOpen();
+    client.disconnect();
+    MockWebSocket.instances[0].simulateClose(1000, true);
+
+    vi.advanceTimersByTime(30000);
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+
+  it("increases reconnection delay with backoff", () => {
+    client.connect();
+    MockWebSocket.instances[0].simulateOpen();
+    MockWebSocket.instances[0].simulateClose(1006, false);
+
+    vi.advanceTimersByTime(2000);
+    expect(MockWebSocket.instances).toHaveLength(2);
+
+    MockWebSocket.instances[1].simulateClose(1006, false);
+    vi.advanceTimersByTime(2000);
+    expect(MockWebSocket.instances).toHaveLength(2);
+    vi.advanceTimersByTime(2000);
+    expect(MockWebSocket.instances).toHaveLength(3);
+  });
+
+  it("resets reconnection attempt counter on successful open", () => {
+    client.connect();
+    MockWebSocket.instances[0].simulateOpen();
+    MockWebSocket.instances[0].simulateClose(1006, false);
+
+    vi.advanceTimersByTime(2000);
+    MockWebSocket.instances[1].simulateOpen();
+    MockWebSocket.instances[1].simulateClose(1006, false);
+
+    vi.advanceTimersByTime(2000);
+    expect(MockWebSocket.instances).toHaveLength(3);
+  });
+
+  it("dispatches to multiple handlers", () => {
+    const handler1 = vi.fn();
+    const handler2 = vi.fn();
+    client.onMessage(handler1);
+    client.onMessage(handler2);
+    client.connect();
+    MockWebSocket.instances[0].simulateOpen();
+
+    MockWebSocket.instances[0].simulateMessage(
+      JSON.stringify({ type: "ack", payload: { receivedType: "test" } })
+    );
+
+    expect(handler1).toHaveBeenCalledTimes(1);
+    expect(handler2).toHaveBeenCalledTimes(1);
+  });
+
+  it("catches handler errors without affecting other handlers", async () => {
+    const errorHandler = vi.fn().mockRejectedValue(new Error("handler fail"));
+    const goodHandler = vi.fn();
+    client.onMessage(errorHandler);
+    client.onMessage(goodHandler);
+    client.connect();
+    MockWebSocket.instances[0].simulateOpen();
+
+    MockWebSocket.instances[0].simulateMessage(
+      JSON.stringify({ type: "ack", payload: { receivedType: "test" } })
+    );
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(goodHandler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/test/mocks/next-navigation.ts
+++ b/frontend/src/test/mocks/next-navigation.ts
@@ -5,6 +5,7 @@ export const mockReplace = vi.fn();
 export const mockBack = vi.fn();
 export const mockRefresh = vi.fn();
 export const mockPathname = vi.fn().mockReturnValue("/dashboard");
+export const mockParams = vi.fn().mockReturnValue({});
 export const mockSearchParams = new URLSearchParams();
 
 vi.mock("next/navigation", () => ({
@@ -16,7 +17,7 @@ vi.mock("next/navigation", () => ({
     prefetch: vi.fn(),
   }),
   usePathname: () => mockPathname(),
-  useParams: () => ({}),
+  useParams: () => mockParams(),
   useSearchParams: () => mockSearchParams,
 }));
 
@@ -26,4 +27,5 @@ export function resetNavigationMocks() {
   mockBack.mockClear();
   mockRefresh.mockClear();
   mockPathname.mockReturnValue("/dashboard");
+  mockParams.mockReturnValue({});
 }

--- a/frontend/src/test/mocks/next-navigation.ts
+++ b/frontend/src/test/mocks/next-navigation.ts
@@ -1,0 +1,29 @@
+import { vi } from "vitest";
+
+export const mockPush = vi.fn();
+export const mockReplace = vi.fn();
+export const mockBack = vi.fn();
+export const mockRefresh = vi.fn();
+export const mockPathname = vi.fn().mockReturnValue("/dashboard");
+export const mockSearchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    replace: mockReplace,
+    back: mockBack,
+    refresh: mockRefresh,
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => mockPathname(),
+  useParams: () => ({}),
+  useSearchParams: () => mockSearchParams,
+}));
+
+export function resetNavigationMocks() {
+  mockPush.mockClear();
+  mockReplace.mockClear();
+  mockBack.mockClear();
+  mockRefresh.mockClear();
+  mockPathname.mockReturnValue("/dashboard");
+}

--- a/frontend/src/test/mocks/supabase.ts
+++ b/frontend/src/test/mocks/supabase.ts
@@ -1,0 +1,48 @@
+import { vi } from "vitest";
+
+export const mockSignInWithPassword = vi.fn();
+export const mockSignUp = vi.fn();
+export const mockSignInWithOAuth = vi.fn();
+export const mockSignOut = vi.fn();
+export const mockGetSession = vi.fn();
+export const mockGetUser = vi.fn();
+
+const mockAuth = {
+  signInWithPassword: mockSignInWithPassword,
+  signUp: mockSignUp,
+  signInWithOAuth: mockSignInWithOAuth,
+  signOut: mockSignOut,
+  getSession: mockGetSession,
+  getUser: mockGetUser,
+  onAuthStateChange: vi.fn().mockReturnValue({
+    data: { subscription: { unsubscribe: vi.fn() } },
+  }),
+};
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({ auth: mockAuth }),
+}));
+
+export function resetSupabaseMocks() {
+  mockSignInWithPassword.mockClear();
+  mockSignUp.mockClear();
+  mockSignInWithOAuth.mockClear();
+  mockSignOut.mockClear();
+  mockGetSession.mockClear();
+  mockGetUser.mockClear();
+}
+
+export function mockSessionWith(accessToken = "fake-token") {
+  mockGetSession.mockResolvedValue({
+    data: {
+      session: {
+        access_token: accessToken,
+        user: { id: "user-1", email: "test@example.com" },
+      },
+    },
+  });
+}
+
+export function mockNoSession() {
+  mockGetSession.mockResolvedValue({ data: { session: null } });
+}

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,0 +1,37 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach, vi } from "vitest";
+
+afterEach(() => {
+  cleanup();
+});
+
+// Stub HTMLCanvasElement.getContext for components that use <canvas>
+HTMLCanvasElement.prototype.getContext = vi.fn().mockReturnValue({
+  clearRect: vi.fn(),
+  beginPath: vi.fn(),
+  moveTo: vi.fn(),
+  lineTo: vi.fn(),
+  stroke: vi.fn(),
+  createLinearGradient: vi.fn().mockReturnValue({
+    addColorStop: vi.fn(),
+  }),
+  setTransform: vi.fn(),
+  strokeStyle: "",
+  lineWidth: 1,
+}) as unknown as typeof HTMLCanvasElement.prototype.getContext;
+
+// Stub window.matchMedia
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import path from "path";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./src/test/setup.ts"],
+    include: ["src/**/*.test.{ts,tsx}"],
+    css: false,
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});


### PR DESCRIPTION
### Summary
Adds a Terms of Service acceptance flow for newly authenticated users. Users are now required to review and accept terms before accessing protected app routes.

### What changed
- Added a dedicated /terms page where users can review Terms of Service content and accept it.
- Added gating logic in the protected app layout to check user.user_metadata.terms_accepted:
- If not accepted, users are redirected to /terms.
- If accepted, normal app navigation continues.
- On acceptance, the frontend updates Supabase user metadata with:
   1. terms_accepted: true
   2. terms_accepted_at: <timestamp>
- Preserved route intent using a next query parameter so users return to the expected destination after accepting terms.

### Behavioral impact
- Users only need to accept terms once per account (unless metadata is reset/changed later).
- This applies to protected in-app routes after sign-up/login, ensuring terms are acknowledged before feature use.

### Technical notes
- Implemented the terms page as a client route and wrapped useSearchParams usage in a Suspense boundary to satisfy Next.js prerender/build requirements.
- Prevents accidental access to app pages without terms acceptance while keeping auth/session handling unchanged.

### Validation
- npm run build succeeds with /terms prerendering correctly.
- Redirect + accept flow verified:
   1. Unaccepted user → /terms
   2. Accept terms → metadata updated and user proceeds into app.

Resolves #197 
Resolves #256 