### PR TITLE
feat: show accuracy on profile page, fix LinkedIn redirect URL

### DIFF
--- a/frontend/src/app/(app)/profile/[userId]/page.tsx
+++ b/frontend/src/app/(app)/profile/[userId]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useRouter, useParams } from "next/navigation";
+import { useRouter, useParams, useSearchParams } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
 import { api, type ProfileResponse } from "@/lib/api";
 import { Aurora } from "@/components/aurora";
@@ -17,7 +17,9 @@ function resolvePhotoUrl(photoPath: string | null): string | null {
 export default function UserProfilePage() {
   const router = useRouter();
   const params = useParams();
+  const searchParams = useSearchParams();
   const userId = params.userId as string;
+  const accuracy = searchParams.get("accuracy");
   const [profile, setProfile] = useState<ProfileResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [imgFailed, setImgFailed] = useState(false);
@@ -144,9 +146,28 @@ export default function UserProfilePage() {
             <p className="mt-1 text-center text-[15px] text-white/50">{profile.headline}</p>
           )}
 
+          {accuracy && (
+            <div className="mt-2 flex items-center gap-1.5">
+              <span
+                className="rounded-full px-3 py-1 text-[12px] font-medium"
+                style={{
+                  background: "oklch(0.35 0.12 275 / 40%)",
+                  border: "1px solid oklch(0.5 0.15 275 / 25%)",
+                  color: "oklch(0.8 0.1 275)",
+                }}
+              >
+                Accuracy: {accuracy}%
+              </span>
+            </div>
+          )}
+
           {profile.linkedin_url && (
             <a
-              href={profile.linkedin_url}
+              href={
+                profile.linkedin_url.startsWith("http")
+                  ? profile.linkedin_url
+                  : `https://${profile.linkedin_url}`
+              }
               target="_blank"
               rel="noopener noreferrer"
               className="mt-3 flex items-center gap-1.5 text-[12px] text-white/30 active:text-white/60"

--- a/frontend/src/app/(app)/recognition/__tests__/recognition-page.test.tsx
+++ b/frontend/src/app/(app)/recognition/__tests__/recognition-page.test.tsx
@@ -236,7 +236,7 @@ describe("RecognitionPage", () => {
 
     await userEvent.click(screen.getByText("Sarah Chen"));
 
-    expect(mockPush).toHaveBeenCalledWith("/profile/user-abc");
+    expect(mockPush).toHaveBeenCalledWith("/profile/user-abc?accuracy=93");
   });
 
   it("caches profile to sessionStorage when clicking a card", async () => {

--- a/frontend/src/app/(app)/recognition/page.tsx
+++ b/frontend/src/app/(app)/recognition/page.tsx
@@ -494,7 +494,12 @@ export default function RecognitionPage() {
                   if (r.profile) {
                     sessionStorage.setItem(`profile_cache_${userId}`, JSON.stringify(r.profile));
                   }
-                  router.push(`/profile/${userId}`);
+                  const params = new URLSearchParams();
+                  if (r.confidence != null) {
+                    params.set("accuracy", String(Math.round(r.confidence)));
+                  }
+                  const qs = params.toString();
+                  router.push(`/profile/${userId}${qs ? `?${qs}` : ""}`);
                 }}
               />
             ))}


### PR DESCRIPTION
## Summary
- Display the face recognition accuracy score on the profile detail page when navigating from a recognition card
- Fix LinkedIn button redirect — URLs without `https://` prefix were being treated as relative paths instead of opening the external LinkedIn profile
- LinkedIn button continues to only appear when the user has a LinkedIn URL in their profile

## Changes
- **`recognition/page.tsx`**: Pass confidence score as `?accuracy=XX` query param when navigating to a profile
- **`profile/[userId]/page.tsx`**: Read `accuracy` param and render an "Accuracy: XX%" badge below the user's name. Also prepend `https://` to LinkedIn URLs that are missing a protocol prefix.

## Test plan
- [ ] Recognize a face → tap the card → verify "Accuracy: XX%" badge appears on the profile page
- [ ] Verify the accuracy badge does NOT appear when navigating to a profile from somewhere other than recognition
- [ ] Verify LinkedIn button opens the correct LinkedIn profile in a new tab
- [ ] Verify LinkedIn button does not appear for users without a LinkedIn URL

Closes #307 