### PR TITLE
fix: use dspy.context to avoid thread-safety crash on profile import

### DIFF
--- a/backend/app/services/compatibility.py
+++ b/backend/app/services/compatibility.py
@@ -190,9 +190,11 @@ def _generate_with_dspy(
     shared_fields: list[str],
 ) -> tuple[float | None, list[str]]:
     """Return (score_or_None, starters). Score is None if DSPy couldn't parse it."""
-    predictor = _get_dspy_predictor(model, api_key)
+    import dspy
+    lm, predictor = _get_dspy_predictor(model, api_key)
     context = _build_context(viewer, target, shared_companies, shared_schools, shared_fields)
-    prediction = predictor(context=context)
+    with dspy.context(lm=lm):
+        prediction = predictor(context=context)
 
     raw_score = str(getattr(prediction, "compatibility_score", "")).strip()
     dspy_score: float | None = None
@@ -238,8 +240,7 @@ def _get_dspy_predictor(model: str, api_key: str):  # pragma: no cover - runtime
         )
 
     lm = dspy.LM(model=model, api_key=api_key)
-    dspy.configure(lm=lm)
-    return dspy.Predict(CompatibilitySignature)
+    return lm, dspy.Predict(CompatibilitySignature)
 
 
 def _template_starters(

--- a/backend/app/services/compatibility.py
+++ b/backend/app/services/compatibility.py
@@ -191,6 +191,7 @@ def _generate_with_dspy(
 ) -> tuple[float | None, list[str]]:
     """Return (score_or_None, starters). Score is None if DSPy couldn't parse it."""
     import dspy
+
     lm, predictor = _get_dspy_predictor(model, api_key)
     context = _build_context(viewer, target, shared_companies, shared_schools, shared_fields)
     with dspy.context(lm=lm):

--- a/backend/app/services/profile_summary.py
+++ b/backend/app/services/profile_summary.py
@@ -66,8 +66,10 @@ class ProfileSummaryService:
         context = _build_profile_context(profile)
 
         try:
-            predictor = _get_dspy_predictor(model, api_key)
-            prediction = predictor(profile_context=context)
+            import dspy
+            lm, predictor = _get_dspy_predictor(model, api_key)
+            with dspy.context(lm=lm):
+                prediction = predictor(profile_context=context)
         except Exception as exc:  # pragma: no cover - network/runtime dependent
             raise ProfileSummaryError(f"DSPy generation failed: {exc}") from exc
 
@@ -194,5 +196,4 @@ def _get_dspy_predictor(model: str, api_key: str):  # pragma: no cover - runtime
         )
 
     lm = dspy.LM(model=model, api_key=api_key)
-    dspy.configure(lm=lm)
-    return dspy.Predict(ProfileSummarySignature)
+    return lm, dspy.Predict(ProfileSummarySignature)

--- a/backend/app/services/profile_summary.py
+++ b/backend/app/services/profile_summary.py
@@ -67,6 +67,7 @@ class ProfileSummaryService:
 
         try:
             import dspy
+
             lm, predictor = _get_dspy_predictor(model, api_key)
             with dspy.context(lm=lm):
                 prediction = predictor(profile_context=context)


### PR DESCRIPTION
## Summary

- LinkedIn profile import was crashing with "dspy.settings can only be changed by the thread that initially configured it"
- Root cause: `dspy.configure(lm=lm)` is thread-locked in DSPy 2.x — the first thread to call it becomes the owner, and any subsequent thread (spawned by `asyncio.to_thread`) throws this error
- Fix: replace `dspy.configure` with `dspy.context(lm=lm)` at the call site in both `ProfileSummaryService` and `CompatibilityService`; the `lru_cache` now returns `(lm, predictor)` so the caller wraps each invocation in the context manager